### PR TITLE
Disable algolia search in admin backend

### DIFF
--- a/core/QueryReplacer.php
+++ b/core/QueryReplacer.php
@@ -67,7 +67,7 @@ class QueryReplacer
 
     public function getOrderedPost($posts)
     {
-        if(! is_search())
+        if(! is_search() || is_admin())
             return $posts;
 
         global $wp_query;


### PR DESCRIPTION
The "post search" field in the admin frontend will not return any results when the plugin is active. This pull request is a workaround to help us solve the problem.  

How to reproduce:
  * Login to wordpress
  * Click on Posts -> All Posts
  * Search with "Search Posts" form in the upper right corner