### PR TITLE
Fixed post type overwriting when filtering product variations

### DIFF
--- a/admin/views/admin_menu.php
+++ b/admin/views/admin_menu.php
@@ -54,7 +54,7 @@ $attributes = array();
 $attributes_additionals_sections = array();
 $typesForAttributes = $types;
 
-if (count(array_filter($types, function ($item) { return $item->name = 'product';})))
+if (count(array_filter($types, function ($item) { return $item->name === 'product';})))
 {
     $product_variation = new stdClass();
     $product_variation->name = 'product_variation';


### PR DESCRIPTION
Hi. While trying to integrate the Algolia plugin with custom post types, I saw that in the admin settings for Algolia, when adding a custom post type to autocomplete types, the custom post type name was being overwritten with what seems an accidental assignation.

Thanks!