### PR TITLE
Missing #instant-search-results-container div close tag

### DIFF
--- a/templates/default/templates.php
+++ b/templates/default/templates.php
@@ -83,7 +83,7 @@ $facets = $facets['facets'];
                                 <div class="pull-right" id="algolia-sorts"></div>
                                 <div class="clearfix"></div>
                             </div>
-                            <div id="instant-search-results-container"
+                            <div id="instant-search-results-container"></div>
                         </div>
                     </div>
                     <div class="clearfix"></div>


### PR DESCRIPTION
I just corrected a small issue on the template files. 