### PR TITLE
Added 'title' to list of options in admin interface under 'Attributes To Index'

### DIFF
--- a/admin/views/admin_menu.php
+++ b/admin/views/admin_menu.php
@@ -96,7 +96,7 @@ foreach ($taxonomies as $taxonomy)
 
 $attributes_additionals_sections = $attributes;
 
-$extras = array('post_title', 'post_content', 'display_name',
+$extras = array('post_title', 'title', 'post_content', 'display_name',
     'post_author', 'post_date', 'post_excerpt', 'post_name', 'post_modified', 'post_parent', 'menu_order', 'post_type',
     'first_name', 'last_name', 'user_login', 'permalink', 'featureImage');
 


### PR DESCRIPTION
The `title` option was missing in the Worpdress plugin but available in the algolia web interface:

![image](https://cloud.githubusercontent.com/assets/410142/16579455/aafff6ce-4297-11e6-8037-75e38cf2f080.png)
