### PR TITLE
chore(configuration): improve the UX when no types have been configured

### DIFF
--- a/wordpress/wp-content/plugins/algolia/admin/class-algolia-admin-page-autocomplete.php
+++ b/wordpress/wp-content/plugins/algolia/admin/class-algolia-admin-page-autocomplete.php
@@ -92,9 +92,11 @@ class Algolia_Admin_Page_Autocomplete
 	 */
 	public function autocomplete_enabled_callback() {
 		$value = $this->settings->get_autocomplete_enabled();
+		$indices = $this->autocomplete_config->get_form_data();
 		$checked = 'yes' === $value ? 'checked ' : '';
+		$disabled = empty( $indices ) ? 'disabled ' : '';
 
-		echo "<input type='checkbox' name='algolia_autocomplete_enabled' value='yes' $checked/>";
+		echo "<input type='checkbox' name='algolia_autocomplete_enabled' value='yes' $checked $disabled/>";
 	}
 
 	/**
@@ -143,5 +145,13 @@ class Algolia_Admin_Page_Autocomplete
 	 */
 	public function print_section_settings() {
 		echo '<p>' . esc_html__( 'The autocomplete options adds a find-as-you-type dropdown menu to your search bar(s).', 'algolia' ) . '</p>';
+
+		$indices = $this->autocomplete_config->get_form_data();
+
+		if ( empty( $indices ) ) {
+			echo '<div class="error-message">' .
+				__( 'You have no indexed content yet. Please index some content on the `Indexing` page.', 'algolia' ) .
+				'</div>';
+		}
 	}
 }

--- a/wordpress/wp-content/plugins/algolia/admin/js/algolia-admin.js
+++ b/wordpress/wp-content/plugins/algolia/admin/js/algolia-admin.js
@@ -17,7 +17,7 @@
 
 		function refresh_native_search_post_type_display()
 		{
-			if ($override_native_search.is(':checked')) {
+			if ($override_native_search.is(':checked') || $override_native_search.is(':disabled')) {
 				show_native_search_post_type();
 			} else {
 				hide_native_search_post_type();
@@ -43,7 +43,7 @@
 
 		function refresh_autocomplete_display()
 		{
-			if ($autocomplete_enabled.is(':checked')) {
+			if ($autocomplete_enabled.is(':checked') || $autocomplete_enabled.is(':disabled')) {
 				show_autocomplete_settings();
 			} else {
 				hide_autocomplete_settings();

--- a/wordpress/wp-content/plugins/algolia/admin/partials/page-autocomplete-config.php
+++ b/wordpress/wp-content/plugins/algolia/admin/partials/page-autocomplete-config.php
@@ -1,7 +1,3 @@
-<?php if ( empty( $indices ) ) : ?>
-	<?php _e( 'You have no indexed content yet. Please index some content on the `Indexing` page.', 'algolia' ); ?>
-<?php else : ?>
-
 <table class="widefat table-autocomplete">
 	<thead>
 		<tr>
@@ -28,6 +24,13 @@
 			</td>
 		</tr>
 		<?php endforeach; ?>
+		<?php if ( empty( $indices ) ) : ?>
+			<tr>
+				<td colspan="4" class="column-comments">
+					<em>You have no indexed content yet.</em>
+				</td>
+			</tr>
+		<?php endif; ?>
 	</tbody>
 </table>
 <p class="description" id="home-description">
@@ -37,5 +40,3 @@
 	<br />
 	<?php _e( 'Use the `Position` column to reflect the order of the sections in the dropdown menu.', 'algolia' ); ?>
 </p>
-
-<?php endif; ?>


### PR DESCRIPTION
 * Ensure the "error" message is readable & displayed first instead of having it instead of the actual configuration input. (We might want to tune the CSS here, I used their default one).
 * Display the inputs with `disabled` states
 * Display the empty table

![screen shot 2016-08-01 at 09 38 24](https://cloud.githubusercontent.com/assets/29529/17286747/b646440e-57cb-11e6-848d-baf19019b004.png)

![screen shot 2016-08-01 at 09 38 12](https://cloud.githubusercontent.com/assets/29529/17286736/adbc46a8-57cb-11e6-85f3-1e549e0d3eb5.png)
