### PR TITLE
load on wp_loaded instead of init

### DIFF
--- a/wordpress/wp-content/plugins/algolia/includes/class-algolia-plugin.php
+++ b/wordpress/wp-content/plugins/algolia/includes/class-algolia-plugin.php
@@ -55,7 +55,7 @@ class Algolia_Plugin {
 		$this->api = new Algolia_API( $this->settings );
 
 		add_action( 'init', array( $this, 'register_post_types'), 5 );
-		add_action( 'init', array( $this, 'load' ) );
+		add_action( 'wp_loaded', array( $this, 'load' ) );
 	}
 
 	/**


### PR DESCRIPTION
Defer loading of the plugin after themes are fully loaded and instantiated so we can index a theme's custom post type.