### PR TITLE
Load indices after other post types are registered

### DIFF
--- a/wordpress/wp-content/plugins/algolia/includes/class-algolia-plugin.php
+++ b/wordpress/wp-content/plugins/algolia/includes/class-algolia-plugin.php
@@ -55,7 +55,7 @@ class Algolia_Plugin {
 		$this->api = new Algolia_API( $this->settings );
 
 		add_action( 'init', array( $this, 'register_post_types'), 5 );
-		add_action( 'init', array( $this, 'load' ) );
+		add_action( 'init', array( $this, 'load' ), 20 );
 	}
 
 	/**


### PR DESCRIPTION
By default WordPress recommends registering post types on the init hook.
Users tend to not provide the 3rd parameter which would result in it being assigned 10.
Here we simply load the indices at 20 instead of the default 10 to make sure we have all user registered post types.

Resolves: #122