### PR TITLE
Customization doc & review

### DIFF
--- a/docs/layouts/page.html
+++ b/docs/layouts/page.html
@@ -52,7 +52,8 @@
             <li class="menu-text">Getting Started</li>
             <li {{ activeClass "installation.md"}}><a href="{{ rootPath }}installation.html">Installation</a></li>
             <li {{ activeClass "configuration.md" }}><a href="{{ rootPath }}configuration.html">Configuration</a></li>
-            <li {{ activeClass "customization.md" }}><a href="{{ rootPath }}customization.html">Customization</a></li>
+            <li {{ activeClass "customize-autocomplete.md" }}><a href="{{ rootPath }}customize-autocomplete.html">Customize Autocomplete</a></li>
+            <li {{ activeClass "customize-search-page.md" }}><a href="{{ rootPath }}customize-search-page.html">Customize Search Page</a></li>
 
             <li class="menu-text">Indexing</li>
             <li {{ activeClass "index-schema.md" }}><a href="{{ rootPath }}index-schema.html">Schemas</a></li>

--- a/docs/src/customization.md
+++ b/docs/src/customization.md
@@ -4,9 +4,11 @@ description: Customize your drop-down menu and instant search results page.
 layout: page.html
 ---
 
-## Introduction
+<div class="alert alert-warning">**Reminder**: You should never directly edit the plugin files because all your changes will be lost at every plugin update.</div>
 
-### Autocomplete
+## Autocomplete
+
+### Introduction
 
 *The autocomplete experience can be enabled in the **Autocomplete** section of the plugin.*
 
@@ -14,32 +16,150 @@ The autocomplete dropdown menu is powered by **autocomplete.js**, a JavaScript l
 
 Please checkout the [github repository of the autocomplete.js library](https://github.com/algolia/autocomplete.js/).
 
-### Instant Search Results Page
+<div class="alert alert-info">Whatever changes you make, be sure to understand how the **autocomplete.js** library work by checking out their official documentations.</div>
 
-*The instant search results experience can be enabled in the **Search page** section of the plugin.*
+### Customization
 
-The instant search results page is powered by **instantsearch.js**, a JavaScript library that eases the process of building rich search experiences.
+To start customizing your dropdown menu, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`. If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
 
-Please checkout the [official documentation of the instantsearch.js website](https://community.algolia.com/instantsearch.js/). Also take a look at some examples of [what can be achieved with instantsearch.js](https://community.algolia.com/instantsearch.js/examples/).
+You can then edit the `algolia/autocomplete.php` file to customize the autocomplete dropdown menu (suggestions, header, footer) templates & associated JavaScript code.
 
-<div class="alert alert-info">The instantsearch feature will do its search on the **Searchable posts** index. If you don't have that index flagged for indexing you will be invited to index it with a notice on every page of the WordPress admin.</div>
+<div class="alert alert-info">All autocomplete.js templates are using the underscore templating, learn more about it reading this [complete documentation](http://www.2ality.com/2012/06/underscore-templates.html).</div>
 
-## Customizations
+#### Edit the suggestion templates
 
-<div class="alert alert-warning">You should never directly edit files of the plugin, because all changes would be lost at every update of the plugin.</div>
+Each autocomplete.js source will display its suggestions with an associated template. To configure them, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-*-suggestion` templates:
 
-To start customizing your dropdown menu and instant-search results pages, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`.
+#### Post template
 
-**Example**: If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
+This is the template used for all **Post**-based types.
 
-Edit the files in your `algolia` folder to customize the look & feel and the overall search experience of your autocomplete and instant search results page.
+```html
+<script type="text/html" id="tmpl-autocomplete-post-suggestion">
+  <a class="suggestion-link" href="{{ data.permalink }}" title="{{ data.post_title }}">
+    <# if ( data.thumbnail_url ) { #>
+    <img class="suggestion-post-thumbnail" src="{{ data.thumbnail_url }}" alt="{{ data.post_title }}">
+    <# } #>
+    <div class="suggestion-post-attributes">
+      <span class="suggestion-post-title">{{{ data._highlightResult.post_title.value }}}</span>
 
- * `autocomplete.php`: The autocomplete dropdown menu (suggestions, header, footer) templates & JavaScript code.
- * `instantsearch.php`: The instantsearch (hits, filters, search bar & pagination) templates & JavaScript code.
+      <#
+      var attributes = ['content', 'title6', 'title5', 'title4', 'title3', 'title2', 'title1'];
+      var attribute_name;
+      var relevant_content = '';
+      for ( var index in attributes ) {
+      attribute_name = attributes[ index ];
+      if ( data._highlightResult[ attribute_name ].matchedWords.length > 0 ) {
+      relevant_content = data._snippetResult[ attribute_name ].value;
+      break;
+      } else if( data._snippetResult[ attribute_name ].value !== '' ) {
+      relevant_content = data._snippetResult[ attribute_name ].value;
+      }
+      }
+      #>
+      <span class="suggestion-post-content">{{{ relevant_content }}}</span>
+    </div>
+  </a>
+</script>
+```
 
-<div class="alert alert-info">Whatever changes you make, be sure to understand how the autocomplete.js & instantsearch.js library work by checking out their official documentations.</div>
+#### Term template
 
-We provide with some default CSS rules that are locate on the `algolia/assets/css/algolia-autocomplete.css` and `algolia/assets/css/algolia-instantsearch.css` stylesheets. You can very easily add your own CSS rules to your theme's stylesheet.
+This is the template used for all **Term**-based types.
+
+```html
+<script type="text/html" id="tmpl-autocomplete-term-suggestion">
+  <a class="suggestion-link" href="{{ data.permalink }}"  title="{{ data.name }}">
+    <svg viewBox="0 0 21 21" width="21" height="21"><svg width="21" height="21" viewBox="0 0 21 21"><path d="M4.662 8.72l-1.23 1.23c-.682.682-.68 1.792.004 2.477l5.135 5.135c.7.693 1.8.688 2.48.005l1.23-1.23 5.35-5.346c.31-.31.54-.92.51-1.36l-.32-4.29c-.09-1.09-1.05-2.06-2.15-2.14l-4.3-.33c-.43-.03-1.05.2-1.36.51l-.79.8-2.27 2.28-2.28 2.27zm9.826-.98c.69 0 1.25-.56 1.25-1.25s-.56-1.25-1.25-1.25-1.25.56-1.25 1.25.56 1.25 1.25 1.25z" fill-rule="evenodd"></path></svg></svg>
+    <span class="suggestion-post-title">{{{ data._highlightResult.name.value }}}</span>
+  </a>
+</script>
+```
+
+#### User template
+
+This is the template used for **Users**.
+
+```html
+<script type="text/html" id="tmpl-autocomplete-user-suggestion">
+  <a class="suggestion-link user-suggestion-link" href="{{ data.posts_url }}"  title="{{ data.display_name }}">
+    <# if ( data.avatar_url ) { #>
+    <img class="suggestion-user-thumbnail" src="{{ data.avatar_url }}" alt="{{ data.display_name }}">
+    <# } #>
+
+    <span class="suggestion-post-title">{{{ data._highlightResult.display_name.value }}}</span>
+  </a>
+</script>
+```
+
+#### Edit the source headers
+
+Each autocomplete.js source will have an associated header displayed before the suggestions. To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-header` template:
+
+```html
+<script type="text/html" id="tmpl-autocomplete-header">
+  <div class="autocomplete-header">
+    <div class="autocomplete-header-title">{{ data.label }}</div>
+    <div class="clear"></div>
+  </div>
+</script>
+```
+
+#### Edit the dropdown menu footer
+
+The dropdown menu is provided with a default footer. To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-footer` template:
+
+```html
+<script type="text/html" id="tmpl-autocomplete-footer">
+  <div class="autocomplete-footer">
+    <div class="autocomplete-footer-branding">
+      <?php esc_html_e( 'Powered by', 'algolia' ); ?>
+      <a href="#" class="algolia-powered-by-link" title="Algolia">
+        <img class="algolia-logo" src="https://www.algolia.com/assets/algolia128x40.png" alt="Algolia" />
+      </a>
+    </div>
+  </div>
+</script>
+```
+
+#### Edit the no results message
+
+When no results are found, autocomplete.js will display a specific template.  To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-empty` template:
+
+```html
+<script type="text/html" id="tmpl-autocomplete-empty">
+  <div class="autocomplete-empty">
+    <?php esc_html_e( 'No results matched your query ', 'algolia' ); ?>
+    <span class="empty-query">{{ data.query }}"</span>
+  </div>
+</script>
+```
+
+#### Adding an extra source
+
+In some cases, you may want to add an extra section to your dropdown menu to search in an external index (of another website you own for instance). In order to achieve that, edit the `algolia/autocomplete.php` file and locate the `autocomplete(...)` call. As you'll see, the 3rd parameter of the function is the array of `sources` you're using.
+
+To add an extra source, just append it to the existing `sources` array, just before the `autocomplete(...)` call:
+
+
+```js
+// new source appended to the `sources` array
+sources.push({
+  source: /* .... */,
+  templates: {
+    header: /* .... */,
+    suggestion: /* .... */
+  }
+});
+
+autocomplete(/* .... */);
+```
+
+You can read more about multi sources/categories autocomplete.js implementation in [this tutorial](https://www.algolia.com/doc/guides/search/auto-complete#multi-category).
+
+#### Look & feel
+
+We provide with some default CSS rules that are located in the `algolia/assets/css/algolia-autocomplete.css`. You can very easily add your own CSS rules to your theme's stylesheet.
 
 If for any reason you don't want the default stylesheet to be included, you can remove it like this:
 
@@ -53,11 +173,136 @@ If for any reason you don't want the default stylesheet to be included, you can 
  * so that it is after the stylesheets were enqueued.
  */
 function my_theme_dequeue_styles() {
-	// Remove the algolia-autocomplete.css.
-	wp_dequeue_style( 'algolia-autocomplete' );
+  // Remove the algolia-autocomplete.css.
+  wp_dequeue_style( 'algolia-autocomplete' );
+}
+add_action( 'wp_print_styles', 'my_theme_dequeue_styles', 100 );
+```
 
-	// Remove the algolia-instantsearch.css.
-	wp_dequeue_style( 'algolia-instantsearch' );
+
+## Search Results Page
+
+### Introduction
+
+*The instant search results experience can be enabled in the **Search page** section of the plugin.*
+
+The instant search results page is powered by **instantsearch.js**, a JavaScript library that eases the process of building rich search experiences.
+
+Please checkout the [official documentation of the instantsearch.js website](https://community.algolia.com/instantsearch.js/). Also take a look at some examples of [what can be achieved with instantsearch.js](https://community.algolia.com/instantsearch.js/examples/).
+
+The instantsearch feature will do its search on the **Searchable posts** index. If you don't have that index flagged for indexing you will be invited to index it with a notice on every page of the WordPress admin.
+
+<div class="alert alert-info">Whatever changes you make, be sure to understand how the **instantsearch.js** library work by checking out their official documentations.</div>
+
+### Customization
+
+To start customizing your search results page, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`. If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
+
+You can then edit the `algolia/instantsearch.php` file to customize the instant search results page (search widgets & page layout).
+
+<div class="alert alert-info">All instantsearch.js templates are using the underscore templating, learn more about it reading this [complete documentation](http://www.2ality.com/2012/06/underscore-templates.html).</div>
+
+#### Edit the page layout
+
+The instant search results page is provided with a default layout. You'll need to slightly customize it to fit your theme's look & feel. To configure the layout, edit the `algolia/instantsearch.php` file and locate the `<div id="ais-wrapper">...</div>` code:
+
+```html
+<div id="ais-wrapper">
+  <main id="ais-main">
+    <div id="algolia-search-box">
+      <div id="algolia-stats"></div>
+      <svg class="search-icon" width="25" height="25" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M24.828 31.657a16.76 16.76 0 0 1-7.992 2.015C7.538 33.672 0 26.134 0 16.836 0 7.538 7.538 0 16.836 0c9.298 0 16.836 7.538 16.836 16.836 0 3.22-.905 6.23-2.475 8.79.288.18.56.395.81.645l5.985 5.986A4.54 4.54 0 0 1 38 38.673a4.535 4.535 0 0 1-6.417-.007l-5.986-5.986a4.545 4.545 0 0 1-.77-1.023zm-7.992-4.046c5.95 0 10.775-4.823 10.775-10.774 0-5.95-4.823-10.775-10.774-10.775-5.95 0-10.775 4.825-10.775 10.776 0 5.95 4.825 10.775 10.776 10.775z" fill-rule="evenodd"></path></svg>
+    </div>
+    <div id="algolia-hits"></div>
+    <div id="algolia-pagination"></div>
+  </main>
+  <aside id="ais-facets">
+    <section class="ais-facets" id="facet-post-types"></section>
+    <section class="ais-facets" id="facet-categories"></section>
+    <section class="ais-facets" id="facet-tags"></section>
+    <section class="ais-facets" id="facet-users"></section>
+  </aside>
+</div>
+```
+
+Edit this HTML layout to change the way the overall page is structured.
+
+#### Edit the hit template
+
+Each matching **Searchable Post** will be rendered with a default hit template. To customize it, edit the `algolia/instantsearch.php` file and locate the `tmpl-hit` template:
+
+```html
+<script type="text/html" id="tmpl-instantsearch-hit">
+  <article itemtype="http://schema.org/Article">
+    <# if ( data.thumbnail_url ) { #>
+    <div class="ais-hits--thumbnail">
+      <a href="{{ data.permalink }}" title="{{ data.post_title }}">
+        <img src="{{ data.thumbnail_url }}" alt="{{ data.post_title }}" title="{{ data.post_title }}" itemprop="image" />
+      </a>
+    </div>
+    <# } #>
+
+    <div class="ais-hits--content">
+      <h2 itemprop="name headline"><a href="{{ data.permalink }}" title="{{ data.post_title }}" itemprop="url">{{{ data._highlightResult.post_title.value }}}</a></h2>
+      <div class="ais-hits--tags">
+        <# for (var index in data.taxonomy_post_tag) { #>
+        <span class="ais-hits--tag">{{ data.taxonomy_post_tag[index].value }}</span>
+        <# } #>
+      </div>
+      <div class="excerpt">
+        <p>
+          <#
+          var attributes = ['content', 'title6', 'title5', 'title4', 'title3', 'title2', 'title1'];
+          var attribute_name;
+          var relevant_content = '';
+          for ( var index in attributes ) {
+            attribute_name = attributes[ index ];
+            if ( data._highlightResult[ attribute_name ].matchedWords.length > 0 ) {
+              relevant_content = data._snippetResult[ attribute_name ].value;
+            }
+          }
+
+          relevant_content = data._snippetResult[ attributes[ 0 ] ].value;
+          #>
+          {{{ relevant_content }}}
+        </p>
+      </div>
+    </div>
+    <div class="ais-clearfix"></div>
+  </article>
+</script>
+```
+
+#### Adding an extra search widget
+
+To add an extra search widget, the best is to follow the [official documentation of instantsearch.js](https://community.algolia.com/instantsearch.js/) and instantiate the widget in the `algolia/instantsearch.php` file, just before the `Search.start()` call.
+
+```js
+// new widget
+search.addWidget(/* ... */);
+
+search.start();
+```
+
+
+#### Look & feel
+
+We provide with some default CSS rules that are located in the `algolia/assets/css/algolia-instantsearch.css`. You can very easily add your own CSS rules to your theme's stylesheet.
+
+If for any reason you don't want the default stylesheet to be included, you can remove it like this:
+
+```php
+<?php
+
+/**
+ * Dequeue default CSS files.
+ *
+ * Hooked to the wp_print_styles action, with a late priority (100),
+ * so that it is after the stylesheets were enqueued.
+ */
+function my_theme_dequeue_styles() {
+  // Remove the algolia-instantsearch.css.
+  wp_dequeue_style( 'algolia-instantsearch' );
 }
 add_action( 'wp_print_styles', 'my_theme_dequeue_styles', 100 );
 ```

--- a/docs/src/customize-autocomplete.md
+++ b/docs/src/customize-autocomplete.md
@@ -1,14 +1,12 @@
 ---
-title: Customization
-description: Customize your drop-down menu and instant search results page.
+title: Customize Autocomplete drop-down
+description: Customize your drop-down menu that appears underneath every search bar of your WordPress website.
 layout: page.html
 ---
 
-<div class="alert alert-warning">**Reminder**: You should never directly edit the plugin files because all your changes will be lost at every plugin update.</div>
+<div class="alert alert-warning">**Reminder**: You should never directly edit the plugin files because all your changes would be lost at every plugin update.</div>
 
-## Autocomplete
-
-### Introduction
+## Introduction
 
 *The autocomplete experience can be enabled in the **Autocomplete** section of the plugin.*
 
@@ -18,7 +16,7 @@ Please checkout the [github repository of the autocomplete.js library](https://g
 
 <div class="alert alert-info">Whatever changes you make, be sure to understand how the **autocomplete.js** library work by checking out their official documentations.</div>
 
-### Customization
+## Customization
 
 To start customizing your dropdown menu, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`. If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
 
@@ -26,11 +24,11 @@ You can then edit the `algolia/autocomplete.php` file to customize the autocompl
 
 <div class="alert alert-info">All autocomplete.js templates are using the underscore templating, learn more about it reading this [complete documentation](http://www.2ality.com/2012/06/underscore-templates.html).</div>
 
-#### Edit the suggestion templates
+## Edit the suggestion templates
 
 Each autocomplete.js source will display its suggestions with an associated template. To configure them, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-*-suggestion` templates:
 
-#### Post template
+## Post template
 
 This is the template used for all **Post**-based types.
 
@@ -63,7 +61,7 @@ This is the template used for all **Post**-based types.
 </script>
 ```
 
-#### Term template
+## Term template
 
 This is the template used for all **Term**-based types.
 
@@ -76,7 +74,7 @@ This is the template used for all **Term**-based types.
 </script>
 ```
 
-#### User template
+## User template
 
 This is the template used for **Users**.
 
@@ -92,7 +90,7 @@ This is the template used for **Users**.
 </script>
 ```
 
-#### Edit the source headers
+## Edit the source headers
 
 Each autocomplete.js source will have an associated header displayed before the suggestions. To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-header` template:
 
@@ -105,7 +103,7 @@ Each autocomplete.js source will have an associated header displayed before the 
 </script>
 ```
 
-#### Edit the dropdown menu footer
+## Edit the dropdown menu footer
 
 The dropdown menu is provided with a default footer. To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-footer` template:
 
@@ -122,7 +120,7 @@ The dropdown menu is provided with a default footer. To configure it, edit the `
 </script>
 ```
 
-#### Edit the no results message
+## Edit the no results message
 
 When no results are found, autocomplete.js will display a specific template.  To configure it, edit the `algolia/autocomplete.php` file and locate the `tmpl-autocomplete-empty` template:
 
@@ -135,7 +133,7 @@ When no results are found, autocomplete.js will display a specific template.  To
 </script>
 ```
 
-#### Adding an extra source
+## Adding an extra source
 
 In some cases, you may want to add an extra section to your dropdown menu to search in an external index (of another website you own for instance). In order to achieve that, edit the `algolia/autocomplete.php` file and locate the `autocomplete(...)` call. As you'll see, the 3rd parameter of the function is the array of `sources` you're using.
 
@@ -157,7 +155,7 @@ autocomplete(/* .... */);
 
 You can read more about multi sources/categories autocomplete.js implementation in [this tutorial](https://www.algolia.com/doc/guides/search/auto-complete#multi-category).
 
-#### Look & feel
+## Look & feel
 
 We provide with some default CSS rules that are located in the `algolia/assets/css/algolia-autocomplete.css`. You can very easily add your own CSS rules to your theme's stylesheet.
 
@@ -180,129 +178,3 @@ add_action( 'wp_print_styles', 'my_theme_dequeue_styles', 100 );
 ```
 
 
-## Search Results Page
-
-### Introduction
-
-*The instant search results experience can be enabled in the **Search page** section of the plugin.*
-
-The instant search results page is powered by **instantsearch.js**, a JavaScript library that eases the process of building rich search experiences.
-
-Please checkout the [official documentation of the instantsearch.js website](https://community.algolia.com/instantsearch.js/). Also take a look at some examples of [what can be achieved with instantsearch.js](https://community.algolia.com/instantsearch.js/examples/).
-
-The instantsearch feature will do its search on the **Searchable posts** index. If you don't have that index flagged for indexing you will be invited to index it with a notice on every page of the WordPress admin.
-
-<div class="alert alert-info">Whatever changes you make, be sure to understand how the **instantsearch.js** library work by checking out their official documentations.</div>
-
-### Customization
-
-To start customizing your search results page, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`. If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
-
-You can then edit the `algolia/instantsearch.php` file to customize the instant search results page (search widgets & page layout).
-
-<div class="alert alert-info">All instantsearch.js templates are using the underscore templating, learn more about it reading this [complete documentation](http://www.2ality.com/2012/06/underscore-templates.html).</div>
-
-#### Edit the page layout
-
-The instant search results page is provided with a default layout. You'll need to slightly customize it to fit your theme's look & feel. To configure the layout, edit the `algolia/instantsearch.php` file and locate the `<div id="ais-wrapper">...</div>` code:
-
-```html
-<div id="ais-wrapper">
-  <main id="ais-main">
-    <div id="algolia-search-box">
-      <div id="algolia-stats"></div>
-      <svg class="search-icon" width="25" height="25" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M24.828 31.657a16.76 16.76 0 0 1-7.992 2.015C7.538 33.672 0 26.134 0 16.836 0 7.538 7.538 0 16.836 0c9.298 0 16.836 7.538 16.836 16.836 0 3.22-.905 6.23-2.475 8.79.288.18.56.395.81.645l5.985 5.986A4.54 4.54 0 0 1 38 38.673a4.535 4.535 0 0 1-6.417-.007l-5.986-5.986a4.545 4.545 0 0 1-.77-1.023zm-7.992-4.046c5.95 0 10.775-4.823 10.775-10.774 0-5.95-4.823-10.775-10.774-10.775-5.95 0-10.775 4.825-10.775 10.776 0 5.95 4.825 10.775 10.776 10.775z" fill-rule="evenodd"></path></svg>
-    </div>
-    <div id="algolia-hits"></div>
-    <div id="algolia-pagination"></div>
-  </main>
-  <aside id="ais-facets">
-    <section class="ais-facets" id="facet-post-types"></section>
-    <section class="ais-facets" id="facet-categories"></section>
-    <section class="ais-facets" id="facet-tags"></section>
-    <section class="ais-facets" id="facet-users"></section>
-  </aside>
-</div>
-```
-
-Edit this HTML layout to change the way the overall page is structured.
-
-#### Edit the hit template
-
-Each matching **Searchable Post** will be rendered with a default hit template. To customize it, edit the `algolia/instantsearch.php` file and locate the `tmpl-hit` template:
-
-```html
-<script type="text/html" id="tmpl-instantsearch-hit">
-  <article itemtype="http://schema.org/Article">
-    <# if ( data.thumbnail_url ) { #>
-    <div class="ais-hits--thumbnail">
-      <a href="{{ data.permalink }}" title="{{ data.post_title }}">
-        <img src="{{ data.thumbnail_url }}" alt="{{ data.post_title }}" title="{{ data.post_title }}" itemprop="image" />
-      </a>
-    </div>
-    <# } #>
-
-    <div class="ais-hits--content">
-      <h2 itemprop="name headline"><a href="{{ data.permalink }}" title="{{ data.post_title }}" itemprop="url">{{{ data._highlightResult.post_title.value }}}</a></h2>
-      <div class="ais-hits--tags">
-        <# for (var index in data.taxonomy_post_tag) { #>
-        <span class="ais-hits--tag">{{ data.taxonomy_post_tag[index].value }}</span>
-        <# } #>
-      </div>
-      <div class="excerpt">
-        <p>
-          <#
-          var attributes = ['content', 'title6', 'title5', 'title4', 'title3', 'title2', 'title1'];
-          var attribute_name;
-          var relevant_content = '';
-          for ( var index in attributes ) {
-            attribute_name = attributes[ index ];
-            if ( data._highlightResult[ attribute_name ].matchedWords.length > 0 ) {
-              relevant_content = data._snippetResult[ attribute_name ].value;
-            }
-          }
-
-          relevant_content = data._snippetResult[ attributes[ 0 ] ].value;
-          #>
-          {{{ relevant_content }}}
-        </p>
-      </div>
-    </div>
-    <div class="ais-clearfix"></div>
-  </article>
-</script>
-```
-
-#### Adding an extra search widget
-
-To add an extra search widget, the best is to follow the [official documentation of instantsearch.js](https://community.algolia.com/instantsearch.js/) and instantiate the widget in the `algolia/instantsearch.php` file, just before the `Search.start()` call.
-
-```js
-// new widget
-search.addWidget(/* ... */);
-
-search.start();
-```
-
-
-#### Look & feel
-
-We provide with some default CSS rules that are located in the `algolia/assets/css/algolia-instantsearch.css`. You can very easily add your own CSS rules to your theme's stylesheet.
-
-If for any reason you don't want the default stylesheet to be included, you can remove it like this:
-
-```php
-<?php
-
-/**
- * Dequeue default CSS files.
- *
- * Hooked to the wp_print_styles action, with a late priority (100),
- * so that it is after the stylesheets were enqueued.
- */
-function my_theme_dequeue_styles() {
-  // Remove the algolia-instantsearch.css.
-  wp_dequeue_style( 'algolia-instantsearch' );
-}
-add_action( 'wp_print_styles', 'my_theme_dequeue_styles', 100 );
-```

--- a/docs/src/customize-search-page.md
+++ b/docs/src/customize-search-page.md
@@ -1,69 +1,135 @@
 ---
-title: Extend Search Page
-description: Discover how to build your custom WordPress search experience with the Algolia plugin.
+title: Customize your search page
+description: Learn how to customize the WordPress search page.
 layout: page.html
 ---
+
+<div class="alert alert-warning">**Reminder**: You should never directly edit the plugin files because all your changes would be lost at every plugin update.</div>
+
 ## Introduction
 
-By default, this plugin is shipped with a way to override the default WordPress search and also provides an as you type experience called "autocomplete".
+*The instant search results experience can be enabled in the **Search page** section of the plugin.*
 
-In your case you may want to provide some very specific search experience depending of the data you have, in the UI you want to build.
+The instant search results page is powered by **instantsearch.js**, a JavaScript library that eases the process of building rich search experiences.
 
-Here we are not going to show you the whole process of creating a full featured custom search experience, because it would probably not be useful for your needs.
+Please checkout the [official documentation of the instantsearch.js website](https://community.algolia.com/instantsearch.js/). Also take a look at some examples of [what can be achieved with instantsearch.js](https://community.algolia.com/instantsearch.js/examples/).
 
-That said we are going to give you some of the resources end extension points the plugin provides allowing you to build any kind of search experience you'd like!
+The instantsearch feature will do its search on the **Searchable posts** index. If you don't have that index flagged for indexing you will be invited to index it with a notice on every page of the WordPress admin.
 
-## Static Assets
+<div class="alert alert-info">Whatever changes you make, be sure to understand how the **instantsearch.js** library work by checking out their official documentations.</div>
 
-This plugin ships with several javascript libraries that can be used for implementing your custom search experience.
+## Customization
 
-|name|description
-|-|-
-|algolia-search|The official Algolia Javascript API Client: https://www.algolia.com/doc/javascript
-|algolia-autocomplete|The official autocomplete.js library: https://github.com/algolia/autocomplete.js
-|algolia-instantsearch|The official instantsearch.js library: https://community.algolia.com/instantsearch.js/
+To start customizing your search results page, copy/paste the `wp-content/plugins/algolia/templates` directory in your own theme, and rename it to `algolia`. If your theme is named `mytheme`, then the folder should look like: `wp-content/themes/mytheme/algolia`.
 
-If you want to create your custom search experience, you should take care of "enqueuing" scripts.
+You can then edit the `algolia/instantsearch.php` file to customize the instant search results page (search widgets & page layout).
 
-The best way would be to declare the scripts as required dependencies:
+<div class="alert alert-info">All instantsearch.js templates are using the underscore templating, learn more about it reading this [complete documentation](http://www.2ality.com/2012/06/underscore-templates.html).</div>
+
+## Edit the page layout
+
+The instant search results page is provided with a default layout. You'll need to slightly customize it to fit your theme's look & feel. To configure the layout, edit the `algolia/instantsearch.php` file and locate the `<div id="ais-wrapper">...</div>` code:
+
+```html
+<div id="ais-wrapper">
+  <main id="ais-main">
+    <div id="algolia-search-box">
+      <div id="algolia-stats"></div>
+      <svg class="search-icon" width="25" height="25" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><path d="M24.828 31.657a16.76 16.76 0 0 1-7.992 2.015C7.538 33.672 0 26.134 0 16.836 0 7.538 7.538 0 16.836 0c9.298 0 16.836 7.538 16.836 16.836 0 3.22-.905 6.23-2.475 8.79.288.18.56.395.81.645l5.985 5.986A4.54 4.54 0 0 1 38 38.673a4.535 4.535 0 0 1-6.417-.007l-5.986-5.986a4.545 4.545 0 0 1-.77-1.023zm-7.992-4.046c5.95 0 10.775-4.823 10.775-10.774 0-5.95-4.823-10.775-10.774-10.775-5.95 0-10.775 4.825-10.775 10.776 0 5.95 4.825 10.775 10.776 10.775z" fill-rule="evenodd"></path></svg>
+    </div>
+    <div id="algolia-hits"></div>
+    <div id="algolia-pagination"></div>
+  </main>
+  <aside id="ais-facets">
+    <section class="ais-facets" id="facet-post-types"></section>
+    <section class="ais-facets" id="facet-categories"></section>
+    <section class="ais-facets" id="facet-tags"></section>
+    <section class="ais-facets" id="facet-users"></section>
+  </aside>
+</div>
+```
+
+Edit this HTML layout to change the way the overall page is structured.
+
+## Edit the hit template
+
+Each matching **Searchable Post** will be rendered with a default hit template. To customize it, edit the `algolia/instantsearch.php` file and locate the `tmpl-hit` template:
+
+```html
+<script type="text/html" id="tmpl-instantsearch-hit">
+  <article itemtype="http://schema.org/Article">
+    <# if ( data.thumbnail_url ) { #>
+    <div class="ais-hits--thumbnail">
+      <a href="{{ data.permalink }}" title="{{ data.post_title }}">
+        <img src="{{ data.thumbnail_url }}" alt="{{ data.post_title }}" title="{{ data.post_title }}" itemprop="image" />
+      </a>
+    </div>
+    <# } #>
+
+    <div class="ais-hits--content">
+      <h2 itemprop="name headline"><a href="{{ data.permalink }}" title="{{ data.post_title }}" itemprop="url">{{{ data._highlightResult.post_title.value }}}</a></h2>
+      <div class="ais-hits--tags">
+        <# for (var index in data.taxonomy_post_tag) { #>
+        <span class="ais-hits--tag">{{ data.taxonomy_post_tag[index].value }}</span>
+        <# } #>
+      </div>
+      <div class="excerpt">
+        <p>
+          <#
+          var attributes = ['content', 'title6', 'title5', 'title4', 'title3', 'title2', 'title1'];
+          var attribute_name;
+          var relevant_content = '';
+          for ( var index in attributes ) {
+            attribute_name = attributes[ index ];
+            if ( data._highlightResult[ attribute_name ].matchedWords.length > 0 ) {
+              relevant_content = data._snippetResult[ attribute_name ].value;
+            }
+          }
+
+          relevant_content = data._snippetResult[ attributes[ 0 ] ].value;
+          #>
+          {{{ relevant_content }}}
+        </p>
+      </div>
+    </div>
+    <div class="ais-clearfix"></div>
+  </article>
+</script>
+```
+
+## Adding an extra search widget
+
+To add an extra search widget, the best is to follow the [official documentation of instantsearch.js](https://community.algolia.com/instantsearch.js/) and instantiate the widget in the `algolia/instantsearch.php` file, just before the `Search.start()` call.
+
+```js
+// new widget
+search.addWidget(/* ... */);
+
+search.start();
+```
+
+
+## Look & feel
+
+We provide with some default CSS rules that are located in the `algolia/assets/css/algolia-instantsearch.css`. You can very easily add your own CSS rules to your theme's stylesheet.
+
+If for any reason you don't want the default stylesheet to be included, you can remove it like this:
 
 ```php
 <?php
 
-function register_custom_search_assets() {
-	wp_enqueue_script( 'custom-search', plugins_url( 'js/custom-search.js', dirname(__FILE__) ), array( 'algolia-search', 'algolia-autocomplete' ) );
+/**
+ * Dequeue default CSS files.
+ *
+ * Hooked to the wp_print_styles action, with a late priority (100),
+ * so that it is after the stylesheets were enqueued.
+ */
+function my_theme_dequeue_styles() {
+  // Remove the algolia-instantsearch.css.
+  wp_dequeue_style( 'algolia-instantsearch' );
 }
-
-add_action( 'wp_enqueue_scripts', 'register_custom_search_assets' );
-```
-This code will ensure that the 'algolia-search' and 'algolia-autocomplete' scripts are also added to the page.
-
-In this example, you can now use the Algolia JS client and the autocomplete library in your custom search script.
-Please take a look at the documentation of the underlying libraries by following the links shared above.
-
-## Work With The Existing Indices
-
-The Algolia Plugin exports a global `$algolia` variable. That variable contains a reference to the `Algolia_Plugin` class.
-
-That class gives you access to all of the features of the plugin.
-
-Here is one way to get the class instance:
-
-```php
-function custom_algolia_usage() {
-	/** @var Algolia_Plugin $algolia */
-	global $algolia;
-
-	// Use the Algolia plugin in your own.
-}
-
-add_action( 'plugins_loaded', 'custom_algolia_usage' );
+add_action( 'wp_print_styles', 'my_theme_dequeue_styles', 100 );
 ```
 
-<div class="alert alert-warning">You should always access the variable once the plugins are loaded. Otherwise, depending on the order in which the user enabled the plugins it could fail.</div>
-
-Now that you have access to the `Algolia_Plugin` instance, you can start using it.
-
-Also be sure to checkout the [custom attributes documentation](custom-attributes.html) which contains a detailed example of a plugin creation.
 
 

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -37,8 +37,6 @@ class Algolia_Template_Loader {
 			'application_id'       => $settings->get_application_id(),
 			'search_api_key'       => $settings->get_search_api_key(),
 			'autocomplete'         => array(
-				'tmpl_empty'  => 'autocomplete-empty',
-				'tmpl_footer' => 'autocomplete-footer',
 				'sources'     => $autocomplete_config->get_config(),
 			),
 			'indices' => array(),

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -365,8 +365,7 @@ abstract class Algolia_Index
 			'label'           => $this->get_admin_name(),
 			'position'        => 10,
 			'max_suggestions' => 5,
-			'tmpl_suggestion' => 'autocomplete-post-suggestion',
-			'tmpl_header' 	   => 'autocomplete-header',
+			'tmpl_suggestion' => 'autocomplete-post-suggestion'
 		);
 	}
 

--- a/templates/autocomplete.php
+++ b/templates/autocomplete.php
@@ -10,7 +10,6 @@
 		<# if ( data.thumbnail_url ) { #>
 		<img class="suggestion-post-thumbnail" src="{{ data.thumbnail_url }}" alt="{{ data.post_title }}">
 		<# } #>
-			
 		<div class="suggestion-post-attributes">
 			<span class="suggestion-post-title">{{{ data._highlightResult.post_title.value }}}</span>
 
@@ -70,87 +69,64 @@
 
 <script type="text/javascript">
 	jQuery(function () {
+		// init Algolia client
 		var client = algoliasearch(algolia.application_id, algolia.search_api_key);
 
+		// setup default sources
 		var sources = [];
-		for(var index in algolia.autocomplete.sources) {
-			var config = algolia.autocomplete.sources[index];
+		jQuery.each(algolia.autocomplete.sources, function(i, config) {
 			sources.push({
-				source: sourceCallback(client.initIndex(config['index_name']), config['max_suggestions']),
+				source: autocomplete.sources.hits(client.initIndex(config['index_name']), {
+					hitsPerPage: config['max_suggestions'],
+					attributesToSnippet: [
+						'content:10',
+						'title1:10',
+						'title2:10',
+						'title3:10',
+						'title4:10',
+						'title5:10',
+						'title6:10'
+					]
+				}),
 				templates: {
-					header: function (label, template) {
-						return function() {
-							return wp.template(template)({
-								label: label
-							});
-						}
-					}(config['label'], config['tmpl_header']),
-					suggestion: function(template) {
-						return wp.template(template);
-					}(config['tmpl_suggestion'])
+					header: function() {
+						return wp.template('autocomplete-header')({
+							label: config['label']
+						});
+					},
+					suggestion: wp.template(config['tmpl_suggestion'])
 				}
 			});
-		}
 
-
-		function sourceCallback( index, max_suggestions ) {
-			return function (q, cb) {
-				index.search(
-					q,
-					{
-						hitsPerPage: max_suggestions,
-						attributesToSnippet: [
-							'content:10',
-							'title1:10',
-							'title2:10',
-							'title3:10',
-							'title4:10',
-							'title5:10',
-							'title6:10'
-						]
-					},
-					function (error, content) {
-						if (error) {
-							cb([]);
-							return;
-						}
-						cb(content.hits, content);
-					});
-			}
-		}
-
-		// Make this come from config as well.
-		var searchInputSelector = "input[name='s']";
-		var searchInput = jQuery(searchInputSelector);
-
-		// Leverage the autocomplete power.
-		autocomplete(searchInputSelector,
-			{
-				debug: algolia.debug,
-				hint: false,
-				openOnFocus: true,
-				templates: {
-					// empty: wp.template(algolia.autocomplete.tmpl_empty), // Waiting for https://github.com/algolia/autocomplete.js/issues/109
-					footer: wp.template(algolia.autocomplete.tmpl_footer)
-				}
-			},
-			sources
-		).on('autocomplete:selected', function(e, suggestion, datasetName) {
-			// Redirect the user when we detect a suggestion selection.
-			window.location.href = suggestion.permalink;
 		});
 
+		// Setup dropdown menus
+		jQuery("input[name='s']").each(function(i) {
+			var $searchInput = jQuery(this);
 
-		// This ensures that when the dropdown overflows the window, Thether can reposition it.
-		jQuery('body').css('overflow-x', 'hidden');
+			// Instantiate autocomplete.js
+			autocomplete($searchInput[0],
+				{
+					debug: algolia.debug,
+					hint: false,
+					openOnFocus: true,
+					templates: {
+						//empty: wp.template('autocomplete-empty'), // Waiting for https://github.com/algolia/autocomplete.js/issues/109
+						footer: wp.template('autocomplete-footer')
+					}
+				},
+				sources
+			).on('autocomplete:selected', function(e, suggestion, datasetName) {
+				// Redirect the user when we detect a suggestion selection.
+				window.location.href = suggestion.permalink;
+			});
 
-		searchInput.each(function(index) {
-			var $item = jQuery(this);
-			var $autocomplete = $item.parent();
+			var $autocomplete = $searchInput.parent();
 
 			// Remove autocomplete.js default inline input search styles.
 			$autocomplete.removeAttr('style');
 
+			// Configure tether
 			var $menu = $autocomplete.find('.aa-dropdown-menu');
 			var config = {
 				element: $menu,
@@ -178,12 +154,10 @@
 					tether.setOptions(config, false);
 				}
 			});
-
-			searchInput.on('autocomplete:updated', function() {
+			$searchInput.on('autocomplete:updated', function() {
 				tether.position();
 			});
-
-			searchInput.on('autocomplete:opened', function() {
+			$searchInput.on('autocomplete:opened', function() {
 				updateDropdownWidth();
 			});
 
@@ -191,24 +165,26 @@
 			// Trick to ensure the autocomplete is always above all.
 			$menu.css('z-index', '99999');
 
-			var dropdownMinWidth = 280;
-
 			// Makes dropdown match the input size.
+			var dropdownMinWidth = 280;
 			function updateDropdownWidth() {
-				var inputWidth = $item.outerWidth();
+				var inputWidth = $searchInput.outerWidth();
 				if (inputWidth >= dropdownMinWidth) {
-					$menu.css('width', $item.outerWidth());
+					$menu.css('width', $searchInput.outerWidth());
 				} else {
 					$menu.css('width', dropdownMinWidth);
 				}
 				tether.position();
 			}
 			jQuery(window).on('resize', updateDropdownWidth);
-		} );
+		});
+
+		// This ensures that when the dropdown overflows the window, Thether can reposition it.
+		jQuery('body').css('overflow-x', 'hidden');
 
 		jQuery(document).on("click", ".algolia-powered-by-link", function(e) {
 			e.preventDefault();
 			window.location = "https://www.algolia.com/?utm_source=WordPress&utm_medium=extension&utm_content=" + window.location.hostname + "&utm_campaign=poweredby";
-		})
+		});
 	});
 </script>


### PR DESCRIPTION
- Improved customization documentation (fix #171, fix #144)
- Cleanup autocomplete.js JS code (header, footer templates shouldn't be set from the
  backend; here and there simplification)
- Replace the Hogan.js based templating (used in instantsearch.js) by Wordpress's underscore
  one. Too complex to work with both.