### PR TITLE
Notify the user if a indexing task fails

### DIFF
--- a/includes/admin/class-algolia-admin-page-indexing.php
+++ b/includes/admin/class-algolia-admin-page-indexing.php
@@ -80,9 +80,10 @@ class Algolia_Admin_Page_Indexing
 	public function queue_status() {
 		$queue = $this->plugin->get_task_queue();
 		wp_send_json( array(
-			'tasks'   => $queue->get_queued_tasks_count(),
-			'running' => $queue->was_recently_running(),
-			'current' => get_transient( 'algolia_running_task' ),
+			'tasks'           => $queue->get_queued_tasks_count(),
+			'running'         => $queue->was_recently_running(),
+			'current'         => get_transient( 'algolia_running_task' ),
+			'recently_failed' => get_transient( 'algolia_recently_failed_task' ),
 		) );
 	}
 

--- a/includes/admin/js/algolia-admin-indexing.js
+++ b/includes/admin/js/algolia-admin-indexing.js
@@ -6,7 +6,8 @@
 		var queueStatus = {
 			tasks: 0,
 			running: false,
-			current: false
+			current: false,
+			recently_failed: false
 		};
 
 		var $pendingTasks = $(".pending-tasks");
@@ -15,6 +16,7 @@
 		var $runQueueLink = $(".run-queue-link");
 		var $currentTask = $(".current-task");
 		var $currentTaskName = $(".current-task-name");
+		var $taskFailed = $(".failed-task");
 
 		function refreshQueueStatus() {
 			$.post("admin-ajax.php", {
@@ -58,6 +60,13 @@
 			} else {
 				$currentTask.hide();
 			}
+
+			if(queueStatus.recently_failed) {
+				$taskFailed.show();
+			} else {
+				$taskFailed.hide();
+			}
+
 		}
 
 		$(".algolia-run-queue").click(function(e) {

--- a/includes/admin/partials/page-indexing.php
+++ b/includes/admin/partials/page-indexing.php
@@ -28,6 +28,9 @@
 			<?php _e( 'Current task', 'algolia' ); ?>:
 			<span class="current-task-name"></span>
 		</p>
+		<p class="failed-task">
+			<?php _e( 'One of your recent tasks failed. Please check the logs for more information.', 'algolia' ); ?>
+		</p>
 	</div>
 
 	<hr>

--- a/includes/class-algolia-task-queue.php
+++ b/includes/class-algolia-task-queue.php
@@ -85,6 +85,7 @@ final class Algolia_Task_Queue
 			if ( ++$retries <= $this->max_task_retries ) {
 				// Just increase the retries.
 				update_post_meta( $task->get_id(), 'algolia_task_retries', $retries );
+				set_transient( 'algolia_recently_failed_task', true, 60);
 				$this->logger->log_error( sprintf( 'An error occurred while handling task %s. It is gonna be retried.', $task->get_name() ), array( 'task' => $task->get_data(), 'exception' => $exception ) );
 			} else {
 				// Consider the task un-processable, delete it and go on!


### PR DESCRIPTION
In this PR, the user will be notified that a task failed to execute.

<img width="553" alt="indexing_ _yoast_ _wordpress" src="https://cloud.githubusercontent.com/assets/5352634/18563001/2b93f2b4-7b86-11e6-85be-fa1da4e81a14.png">

The notification lasts for 60 seconds.

This can easily be tested by disconnecting your internet before hitting the "Re-index everything" button.