### PR TITLE
Fix horizontal overflow on docs homepage

### DIFF
--- a/docs/src/sass/components/_community.scss
+++ b/docs/src/sass/components/_community.scss
@@ -1,5 +1,6 @@
 .community-content-wrapper {
   margin-top: $navigation-height;
+  overflow: hidden;
   article {
     padding: 0;
   }


### PR DESCRIPTION
Fixes the horizontal overflow
![image](https://cloud.githubusercontent.com/assets/5570853/18904791/355d8e48-8560-11e6-9e61-6932e6c9768c.png)
