### PR TITLE
Add controls to the queue and improve monitoring display

### DIFF
--- a/includes/admin/class-algolia-admin-page-indexing.php
+++ b/includes/admin/class-algolia-admin-page-indexing.php
@@ -45,6 +45,7 @@ class Algolia_Admin_Page_Indexing
 		add_action( 'wp_ajax_algolia_queue_status', array( $this, 'queue_status' ) );
 
 		add_action( 'admin_post_algolia_re_index_all', array( $this, 're_index_all' ) );
+		add_action( 'admin_post_algolia_delete_pending_tasks', array( $this, 'delete_pending_tasks' ) );
 
 		if ( get_transient( 'algolia_indices_notice' ) ) {
 			add_action( 'admin_notices', array( $this, 'post_types_notice' ) );
@@ -57,6 +58,11 @@ class Algolia_Admin_Page_Indexing
 		if ( get_transient( 'algolia_all_re_indexed' ) ) {
 			delete_transient( 'algolia_all_re_indexed' );
 			add_action( 'admin_notices', array( $this, 'all_re_indexed_notice' ) );
+		}
+
+		if ( get_transient( 'algolia_deleted_pending_tasks' ) ) {
+			delete_transient( 'algolia_deleted_pending_tasks' );
+			add_action( 'admin_notices', array( $this, 'deleted_pending_tasks_notice' ) );
 		}
 		$this->plugin = $plugin;
 	}
@@ -98,9 +104,22 @@ class Algolia_Admin_Page_Indexing
 		wp_redirect( admin_url( 'admin.php?page=' . $this->slug ) );
 	}
 
+	public function delete_pending_tasks() {
+		Algolia_Task::delete_all_tasks();
+
+		set_transient( 'algolia_deleted_pending_tasks', true );
+		wp_redirect( admin_url( 'admin.php?page=' . $this->slug ) );
+	}
+
 	public function all_re_indexed_notice() {
 		echo '<div class="updated notice">
 			      <p>' . esc_html__( 'All indices were queued for re-indexing.', 'algolia' ) . '</p>
+			  </div>';
+	}
+
+	public function deleted_pending_tasks_notice() {
+		echo '<div class="updated notice">
+			      <p>' . esc_html__( 'All pending tasks were deleted.', 'algolia' ) . '</p>
 			  </div>';
 	}
 

--- a/includes/admin/class-algolia-admin-page-indexing.php
+++ b/includes/admin/class-algolia-admin-page-indexing.php
@@ -42,6 +42,7 @@ class Algolia_Admin_Page_Indexing
 		add_action( 'update_option_algolia_synced_indices_ids', array( $this, 'synced_indices_ids_updated' ), 10, 2 );
 
 		add_action( 'wp_ajax_algolia_run_queue', array( $this, 'run_queue' ) );
+		add_action( 'wp_ajax_algolia_stop_queue', array( $this, 'stop_queue' ) );
 		add_action( 'wp_ajax_algolia_queue_status', array( $this, 'queue_status' ) );
 
 		add_action( 'admin_post_algolia_re_index_all', array( $this, 're_index_all' ) );
@@ -80,6 +81,11 @@ class Algolia_Admin_Page_Indexing
 
 	public function run_queue() {
 		do_action( 'algolia_process_queue' );
+		wp_die();
+	}
+
+	public function stop_queue() {
+		set_transient( 'algolia_stop_queue', true );
 		wp_die();
 	}
 

--- a/includes/admin/css/algolia-admin.css
+++ b/includes/admin/css/algolia-admin.css
@@ -49,7 +49,11 @@ form .radio-info {
 }
 
 /* Indexing page */
-.failed-task {
+.failed-task, .status-running, .status-idle, #delete-pending-tasks, .current-task, .run-queue-link {
+    display: none;
+}
+
+#delete-pending-tasks {
     display: none;
 }
 

--- a/includes/admin/css/algolia-admin.css
+++ b/includes/admin/css/algolia-admin.css
@@ -49,7 +49,7 @@ form .radio-info {
 }
 
 /* Indexing page */
-.failed-task, .status-running, .status-idle, #delete-pending-tasks, .current-task, .run-queue-link {
+.failed-task, .status-running, .status-idle, #delete-pending-tasks, .current-task, .run-queue-link, .stop-queue-link {
     display: none;
 }
 

--- a/includes/admin/js/algolia-admin-indexing.js
+++ b/includes/admin/js/algolia-admin-indexing.js
@@ -17,6 +17,7 @@
 		var $currentTask = $(".current-task");
 		var $currentTaskName = $(".current-task-name");
 		var $taskFailed = $(".failed-task");
+		var $deleteTasksBtn = $('#delete-pending-tasks');
 
 		function refreshQueueStatus() {
 			$.post("admin-ajax.php", {
@@ -24,6 +25,7 @@
 			}, function(data) {
 				queueStatus = data;
 				updateDisplay();
+				setTimeout(refreshQueueStatus, 3000);
 			});
 		}
 
@@ -41,17 +43,21 @@
 			}
 			$currentTaskName.html(taskName);
 
-			if(queueStatus.running) {
+			if(queueStatus.running && queueStatus.tasks > 0) {
 				$statusRunning.show();
 				$statusIdle.hide();
+				$deleteTasksBtn.hide();
+				$runQueueLink.hide();
 			} else {
 				$statusRunning.hide();
 				$statusIdle.show();
 
 				if(queueStatus.tasks > 0) {
 					$runQueueLink.show();
+					$deleteTasksBtn.show();
 				} else {
 					$runQueueLink.hide();
+					$deleteTasksBtn.hide();
 				}
 			}
 
@@ -69,7 +75,7 @@
 
 		}
 
-		$(".algolia-run-queue").click(function(e) {
+		$runQueueLink.click(function(e) {
 			e.preventDefault();
 			$.post("admin-ajax.php", {
 				action: "algolia_run_queue"
@@ -78,8 +84,5 @@
 		});
 
 		refreshQueueStatus();
-
-		// Refresh every 3 seconds.
-		setInterval(refreshQueueStatus, 3000);
 	});
 })( jQuery );

--- a/includes/admin/js/algolia-admin-indexing.js
+++ b/includes/admin/js/algolia-admin-indexing.js
@@ -14,6 +14,7 @@
 		var $statusRunning = $(".status-running");
 		var $statusIdle = $(".status-idle");
 		var $runQueueLink = $(".run-queue-link");
+		var $stopQueueLink = $(".stop-queue-link");
 		var $currentTask = $(".current-task");
 		var $currentTaskName = $(".current-task-name");
 		var $taskFailed = $(".failed-task");
@@ -48,9 +49,11 @@
 				$statusIdle.hide();
 				$deleteTasksBtn.hide();
 				$runQueueLink.hide();
+				$stopQueueLink.show();
 			} else {
 				$statusRunning.hide();
 				$statusIdle.show();
+				$stopQueueLink.hide();
 
 				if(queueStatus.tasks > 0) {
 					$runQueueLink.show();
@@ -80,7 +83,13 @@
 			$.post("admin-ajax.php", {
 				action: "algolia_run_queue"
 			});
-			refreshQueueStatus();
+		});
+
+		$stopQueueLink.click(function(e) {
+			e.preventDefault();
+			$.post("admin-ajax.php", {
+				action: "algolia_stop_queue"
+			});
 		});
 
 		refreshQueueStatus();

--- a/includes/admin/partials/page-indexing.php
+++ b/includes/admin/partials/page-indexing.php
@@ -31,6 +31,9 @@
 							<span class="run-queue-link">
 								<a href="#" class="page-title-action algolia-run-queue"><?php echo __( 'Process queue', 'algolia' ); ?></a>
 							</span>
+							<span class="stop-queue-link">
+								<a href="#" class="page-title-action algolia-stop-queue"><?php echo __( 'Stop queue processing', 'algolia' ); ?></a>
+							</span>
 					</td>
 				</tr>
 				<tr>

--- a/includes/admin/partials/page-indexing.php
+++ b/includes/admin/partials/page-indexing.php
@@ -7,33 +7,56 @@
 	</h1>
 
 	<div class="queue-status">
-		<p>
-			<?php _e( 'Task Queue pending tasks', 'algolia' ); ?> :
-			<strong class="pending-tasks"><?php echo Algolia_Task::get_queued_tasks_count(); ?></strong>
-		</p>
-		<p>
-			<?php _e( 'Task Queue status', 'algolia' ); ?>:
-			
-			<span class="status-running"><strong><?php _e( 'Running', 'algolia' ); ?></strong></span>
-			
-			<span class="status-idle">
-				<strong><?php _e( 'Idle', 'algolia' ); ?>
-					<span class="run-queue-link">
-						| <a href="#" class="page-title-action algolia-run-queue"><?php echo __( 'Process queue', 'algolia' ); ?></a>
-					</span>
-				</strong>
-			</span>
-		</p>
-		<p class="current-task">
-			<?php _e( 'Current task', 'algolia' ); ?>:
-			<span class="current-task-name"></span>
-		</p>
-		<p class="failed-task">
+		<h2><?php _e( 'Queue Monitoring', 'algolia' ); ?></h2>
+		<table class="widefat">
+			<thead>
+				<tr>
+					<td>#</td>
+					<th>Status (refreshed every 3s.)</th>
+					<th>Actions</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><?php _e( 'Queue status', 'algolia' ); ?></td>
+					<td>
+							<span class="status-running">
+								<strong><?php _e( 'Running', 'algolia' ); ?></strong>
+							</span>
+							<span class="status-idle">
+								<strong><?php _e( 'Idle', 'algolia' ); ?></strong>
+							</span>
+					</td>
+					<td>
+							<span class="run-queue-link">
+								<a href="#" class="page-title-action algolia-run-queue"><?php echo __( 'Process queue', 'algolia' ); ?></a>
+							</span>
+					</td>
+				</tr>
+				<tr>
+					<td><?php _e( 'Pending tasks', 'algolia' ); ?></td>
+					<td>
+						<strong class="pending-tasks"><?php echo Algolia_Task::get_queued_tasks_count(); ?></strong>
+					</td>
+					<td>
+						<a href="<?php echo admin_url( 'admin-post.php?action=algolia_delete_pending_tasks' ); ?>" id="delete-pending-tasks" class="page-title-action"><?php _e( 'Delete all pending tasks', 'algolia' ); ?></a>
+					</td>
+				</tr>
+				<tr class="current-task">
+					<td>
+						<?php _e( 'Current task', 'algolia' ); ?>
+					</td>
+					<td class="current-task-name"></td>
+					<td></td>
+				</tr>
+			</tbody>
+		</table>
+
+		<p class="failed-task error-message">
 			<?php _e( 'One of your recent tasks failed. Please check the logs for more information.', 'algolia' ); ?>
 		</p>
 	</div>
-
-	<hr>
+	
 	
 	<form method="post" action="options.php">
 		<?php

--- a/includes/class-algolia-task-queue.php
+++ b/includes/class-algolia-task-queue.php
@@ -56,6 +56,13 @@ final class Algolia_Task_Queue
 		if ( $this->is_running() ) {
 			return $this->logger->log( sprintf( 'Queue is already being handled.' ) );
 		}
+		
+		$should_stop = get_transient( 'algolia_stop_queue' );
+		if ( $should_stop ) {
+			delete_transient( 'algolia_stop_queue' );
+			$this->logger->log( 'Queue was manually stopped' );
+			return;
+		}
 
 		$task = Algolia_Task::get_first();
 

--- a/includes/class-algolia-task-queue.php
+++ b/includes/class-algolia-task-queue.php
@@ -89,8 +89,13 @@ final class Algolia_Task_Queue
 				$this->logger->log_error( sprintf( 'An error occurred while handling task %s. It is gonna be retried.', $task->get_name() ), array( 'task' => $task->get_data(), 'exception' => $exception ) );
 			} else {
 				// Consider the task un-processable, delete it and go on!
-				$task->delete();
-				$this->logger->log_error( sprintf( 'Task %s was deleted after %d attempts to process it.', $task->get_name(), $this->max_task_retries ), array( 'task' => $task->get_data(), 'exception' => $exception ) );
+				$this->logger->log_error( sprintf( 'Queue processing stopped after trying to handle task %s %d times.', $task->get_name(), $this->max_task_retries ), array( 'task' => $task->get_data(), 'exception' => $exception ) );
+
+				// Let's reset the retry count for next queue processing attempt.
+				delete_post_meta( $task->get_id(), 'algolia_task_retries' );
+
+				// We need to return here to stop the queue processing.
+				return;
 			}
 		}
 

--- a/includes/class-algolia-task.php
+++ b/includes/class-algolia-task.php
@@ -130,4 +130,21 @@ class Algolia_Task
 	public function delete() {
 		wp_delete_post( (int) $this->post->ID, true );
 	}
+
+	/**
+	 * Delete all tasks.
+	 */
+	public static function delete_all_tasks() {
+		$query = new WP_Query( array(
+			'post_type'      => self::$post_type,
+			'post_status'    => 'private',
+			'nopaging'       => true,
+			'posts_per_page' => -1,
+			'fields'	     => 'ids',
+		) );
+
+		foreach ( $query->posts as $id ) {
+			wp_delete_post( $id, true );
+		}
+	}
 }

--- a/languages/algolia.pot
+++ b/languages/algolia.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: algolia\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-01 11:21+0200\n"
+"POT-Creation-Date: 2016-10-01 11:39+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,75 +68,75 @@ msgid ""
 "search bar(s)."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:116
+#: includes/admin/class-algolia-admin-page-indexing.php:122
 msgid "All indices were queued for re-indexing."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:122
+#: includes/admin/class-algolia-admin-page-indexing.php:128
 msgid "All pending tasks were deleted."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:129
-#: includes/admin/class-algolia-admin-page-indexing.php:130
+#: includes/admin/class-algolia-admin-page-indexing.php:135
+#: includes/admin/class-algolia-admin-page-indexing.php:136
 msgid "Indexing"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:140
+#: includes/admin/class-algolia-admin-page-indexing.php:146
 msgid "Content Types"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:147
+#: includes/admin/class-algolia-admin-page-indexing.php:153
 msgid "Index name prefix"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:155
+#: includes/admin/class-algolia-admin-page-indexing.php:161
 msgid "Indices"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:185
+#: includes/admin/class-algolia-admin-page-indexing.php:191
 msgid ""
 "Each Content type is pushed to its own Algolia index. Configure here the "
 "list of indices you want to use."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:196
+#: includes/admin/class-algolia-admin-page-indexing.php:202
 msgid "This prefix will be added to your index names."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:233
+#: includes/admin/class-algolia-admin-page-indexing.php:239
 msgid ""
 "Indices prefix can only contain alphanumeric characters and underscores."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:289
+#: includes/admin/class-algolia-admin-page-indexing.php:295
 #, php-format
 msgid "Queued re-indexing of: %s."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:292
+#: includes/admin/class-algolia-admin-page-indexing.php:298
 #, php-format
 msgid "Queued de-indexing of: %s."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:323
+#: includes/admin/class-algolia-admin-page-indexing.php:329
 msgid ""
 "Your new index prefix has correctly been taken into account. If you had "
 "indexed data with the previous index prefix, the indices will be renamed to "
 "reflect the change."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:355
+#: includes/admin/class-algolia-admin-page-indexing.php:361
 #, php-format
 msgid ""
 "You have no indexed content in Algolia. Please index some content on the <a "
 "href=\"%s\">Algolia: Indexing page</a>."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:364
+#: includes/admin/class-algolia-admin-page-indexing.php:370
 msgid "Configure here the content types you want to push to Algolia."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:365
+#: includes/admin/class-algolia-admin-page-indexing.php:371
 msgid ""
 "Changing configuration will automatically schedule a new indexation task."
 msgstr ""
@@ -402,19 +402,23 @@ msgstr ""
 msgid "Process queue"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:37
+#: includes/admin/partials/page-indexing.php:35
+msgid "Stop queue processing"
+msgstr ""
+
+#: includes/admin/partials/page-indexing.php:40
 msgid "Pending tasks"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:42
+#: includes/admin/partials/page-indexing.php:45
 msgid "Delete all pending tasks"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:47
+#: includes/admin/partials/page-indexing.php:50
 msgid "Current task"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:56
+#: includes/admin/partials/page-indexing.php:59
 msgid ""
 "One of your recent tasks failed. Please check the logs for more information."
 msgstr ""

--- a/languages/algolia.pot
+++ b/languages/algolia.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: algolia\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-10-01 09:48+0200\n"
+"POT-Creation-Date: 2016-10-01 11:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -68,71 +68,75 @@ msgid ""
 "search bar(s)."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:103
+#: includes/admin/class-algolia-admin-page-indexing.php:116
 msgid "All indices were queued for re-indexing."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:110
-#: includes/admin/class-algolia-admin-page-indexing.php:111
+#: includes/admin/class-algolia-admin-page-indexing.php:122
+msgid "All pending tasks were deleted."
+msgstr ""
+
+#: includes/admin/class-algolia-admin-page-indexing.php:129
+#: includes/admin/class-algolia-admin-page-indexing.php:130
 msgid "Indexing"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:121
+#: includes/admin/class-algolia-admin-page-indexing.php:140
 msgid "Content Types"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:128
+#: includes/admin/class-algolia-admin-page-indexing.php:147
 msgid "Index name prefix"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:136
+#: includes/admin/class-algolia-admin-page-indexing.php:155
 msgid "Indices"
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:166
+#: includes/admin/class-algolia-admin-page-indexing.php:185
 msgid ""
 "Each Content type is pushed to its own Algolia index. Configure here the "
 "list of indices you want to use."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:177
+#: includes/admin/class-algolia-admin-page-indexing.php:196
 msgid "This prefix will be added to your index names."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:214
+#: includes/admin/class-algolia-admin-page-indexing.php:233
 msgid ""
 "Indices prefix can only contain alphanumeric characters and underscores."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:270
+#: includes/admin/class-algolia-admin-page-indexing.php:289
 #, php-format
 msgid "Queued re-indexing of: %s."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:273
+#: includes/admin/class-algolia-admin-page-indexing.php:292
 #, php-format
 msgid "Queued de-indexing of: %s."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:304
+#: includes/admin/class-algolia-admin-page-indexing.php:323
 msgid ""
 "Your new index prefix has correctly been taken into account. If you had "
 "indexed data with the previous index prefix, the indices will be renamed to "
 "reflect the change."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:336
+#: includes/admin/class-algolia-admin-page-indexing.php:355
 #, php-format
 msgid ""
 "You have no indexed content in Algolia. Please index some content on the <a "
 "href=\"%s\">Algolia: Indexing page</a>."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:345
+#: includes/admin/class-algolia-admin-page-indexing.php:364
 msgid "Configure here the content types you want to push to Algolia."
 msgstr ""
 
-#: includes/admin/class-algolia-admin-page-indexing.php:346
+#: includes/admin/class-algolia-admin-page-indexing.php:365
 msgid ""
 "Changing configuration will automatically schedule a new indexation task."
 msgstr ""
@@ -378,31 +382,39 @@ msgstr ""
 msgid "Re-index everything"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:11
-msgid "Task Queue pending tasks"
+#: includes/admin/partials/page-indexing.php:10
+msgid "Queue Monitoring"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:15
-msgid "Task Queue status"
+#: includes/admin/partials/page-indexing.php:21
+msgid "Queue status"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:17
+#: includes/admin/partials/page-indexing.php:24
 msgid "Running"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:20
+#: includes/admin/partials/page-indexing.php:27
 msgid "Idle"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:22
+#: includes/admin/partials/page-indexing.php:32
 msgid "Process queue"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:28
+#: includes/admin/partials/page-indexing.php:37
+msgid "Pending tasks"
+msgstr ""
+
+#: includes/admin/partials/page-indexing.php:42
+msgid "Delete all pending tasks"
+msgstr ""
+
+#: includes/admin/partials/page-indexing.php:47
 msgid "Current task"
 msgstr ""
 
-#: includes/admin/partials/page-indexing.php:32
+#: includes/admin/partials/page-indexing.php:56
 msgid ""
 "One of your recent tasks failed. Please check the logs for more information."
 msgstr ""


### PR DESCRIPTION
* Re-designed the queue monitoring section
* Add a way to manually stop the queue
* No longer trash failing tasks but stop the queue instead
* Add a button for deleting all pending tasks

Resolves: #129, #341, #157