### PR TITLE
Reduce landing page size by optimizing images

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -11,6 +11,7 @@ var asset       = require('metalsmith-static');
 var helpers     = require('metalsmith-register-helpers');
 var headingsid  = require('metalsmith-headings-identifier');
 var file        = require('./plugins/file/index.js');
+var imagemin    = require('metalsmith-imagemin')
 
 var sassPaths = [
     'node_modules/foundation-sites/scss'
@@ -46,6 +47,13 @@ var siteBuild = Metalsmith(__dirname)
     .use(asset({
         src: './node_modules/foundation-sites/dist',
         dest: './vendor/foundation-sites'
+    }))
+
+    .use(imagemin({
+        gifsicle: {},
+        jpegrecompress: { quality: 'medium' },
+        pngquant: { quality: '65-80' },
+        svgo: {}
     }))
 
     // Add Highlight.js for code snippets.

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,6 +2,7 @@
   "name": "algoliasearch-wordpress-plugin-docs",
   "private": true,
   "dependencies": {
+    "babel-runtime": "^6.11.6",
     "cheerio": "^0.20.0",
     "foundation-sites": "^6.2.3",
     "gh-pages": "^0.11.0",
@@ -10,6 +11,7 @@
     "lodash": "^4.13.1",
     "metalsmith": "^2.1.0",
     "metalsmith-headings-identifier": "0.0.11",
+    "metalsmith-imagemin": "^2.0.0",
     "metalsmith-layouts": "^1.6.5",
     "metalsmith-mapsite": "^1.0.4",
     "metalsmith-markdown": "^0.2.1",


### PR DESCRIPTION
Brings down the total size of the page from 1.8M to 600kb.

/cc @Shipow 
