### PR TITLE
fallback fonts in facets-illus.svg

### DIFF
--- a/docs/src/img/facets-illus.svg
+++ b/docs/src/img/facets-illus.svg
@@ -1,5 +1,4 @@
-
-<svg xmlns="http://www.w3.org/2000/svg" width="522" height="330" viewBox="0 0 522 330" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 522 330" xmlns:xlink="http://www.w3.org/1999/xlink">
   <defs>
     <rect id="a" width="330" height="324" rx="4"/>
     <filter id="j" width="200%" height="200%" x="-50%" y="-50%" filterUnits="objectBoundingBox">
@@ -10,18 +9,18 @@
       <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.1 0" in="shadowBlurOuter1"/>
     </filter>
     <mask id="k" width="332" height="326" x="-1" y="-1">
-      <rect width="332" height="326" x="-1" y="-1" fill="white"/>
-      <use fill="black" xlink:href="#a"/>
+      <path fill="#fff" d="M-1-1h332v326H-1z"/>
+      <use xlink:href="#a"/>
     </mask>
     <linearGradient id="m" x1="50%" x2="50%" y1="0%" y2="100%">
       <stop stop-color="#2B91FC" offset="0%"/>
       <stop stop-color="#2D91FC" offset="100%"/>
     </linearGradient>
-    <path id="b" d="M0,3.00335124 C0,1.34464615 1.34237885,0 3.00335124,0 L10.9966488,0 C12.6553538,0 14,1.34237885 14,3.00335124 L14,10.9966488 C14,12.6553538 12.6576211,14 10.9966488,14 L3.00335124,14 C1.34464615,14 0,12.6576211 0,10.9966488 L0,3.00335124 Z"/>
-    <mask id="n" width="14" height="14" x="0" y="0" fill="white">
+    <path id="b" d="M0 3.003C0 1.345 1.342 0 3.003 0h7.994C12.655 0 14 1.342 14 3.003v7.994C14 12.655 12.658 14 10.997 14H3.003C1.345 14 0 12.658 0 10.997V3.003z"/>
+    <mask id="n" width="14" height="14" x="0" y="0" fill="#fff">
       <use xlink:href="#b"/>
     </mask>
-    <polyline id="p" points="3.9 7.909 6.002 10.294 10.233 3.76"/>
+    <path id="p" d="M3.9 7.91l2.102 2.384 4.23-6.534"/>
     <filter id="o" width="200%" height="200%" x="-50%" y="-50%" filterUnits="objectBoundingBox">
       <feMorphology radius=".75" operator="dilate" in="SourceAlpha" result="shadowSpreadOuter1"/>
       <feOffset dy="1" in="shadowSpreadOuter1" result="shadowOffsetOuter1"/>
@@ -42,7 +41,7 @@
       <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
       <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.196246603 0" in="shadowInnerInner1"/>
     </filter>
-    <mask id="s" width="14" height="14" x="0" y="0" fill="white">
+    <mask id="s" width="14" height="14" x="0" y="0" fill="#fff">
       <use xlink:href="#c"/>
     </mask>
     <rect id="d" width="14" height="14" rx="3"/>
@@ -52,145 +51,138 @@
       <feComposite in="shadowOffsetInner1" in2="SourceAlpha" operator="arithmetic" k2="-1" k3="1" result="shadowInnerInner1"/>
       <feColorMatrix values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.196246603 0" in="shadowInnerInner1"/>
     </filter>
-    <mask id="u" width="14" height="14" x="0" y="0" fill="white">
+    <mask id="u" width="14" height="14" x="0" y="0" fill="#fff">
       <use xlink:href="#d"/>
     </mask>
     <rect id="e" width="68" height="34" rx="3"/>
-    <mask id="v" width="68" height="34" x="0" y="0" fill="white">
+    <mask id="v" width="68" height="34" x="0" y="0" fill="#fff">
       <use xlink:href="#e"/>
     </mask>
     <rect id="f" width="131" height="34" rx="3"/>
-    <mask id="w" width="131" height="34" x="0" y="0" fill="white">
+    <mask id="w" width="131" height="34" x="0" y="0" fill="#fff">
       <use xlink:href="#f"/>
     </mask>
     <rect id="g" width="66" height="34" rx="3"/>
-    <mask id="x" width="66" height="34" x="0" y="0" fill="white">
+    <mask id="x" width="66" height="34" x="0" y="0" fill="#fff">
       <use xlink:href="#g"/>
     </mask>
     <rect id="h" width="66" height="34" rx="3"/>
-    <mask id="y" width="66" height="34" x="0" y="0" fill="white">
+    <mask id="y" width="66" height="34" x="0" y="0" fill="#fff">
       <use xlink:href="#h"/>
     </mask>
     <rect id="i" width="85" height="34" rx="3"/>
-    <mask id="z" width="85" height="34" x="0" y="0" fill="white">
+    <mask id="z" width="85" height="34" x="0" y="0" fill="#fff">
       <use xlink:href="#i"/>
     </mask>
   </defs>
-  <g fill="none" fill-rule="evenodd" transform="translate(0 1)">
-    <g transform="translate(189)">
-      <mask id="l" fill="white">
+  <g fill="none" fill-rule="evenodd">
+    <g transform="translate(189 1)">
+      <mask id="l" fill="#fff">
         <use xlink:href="#a"/>
       </mask>
-      <use fill="black" filter="url(#j)" xlink:href="#a"/>
-      <use fill="#FFFFFF" xlink:href="#a"/>
+      <use fill="#000" filter="url(#j)" xlink:href="#a"/>
+      <use fill="#FFF" xlink:href="#a"/>
       <use stroke="#D8D9DE" stroke-width="2" mask="url(#k)" xlink:href="#a"/>
-      <text fill="#46AEDA" mask="url(#l)" font-family="OpenSans-Semibold, Open Sans" font-size="14" font-weight="500">
+      <text fill="#46AEDA" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-weight="500">
         <tspan x="12" y="27">Deep linking &amp; search in iOS 9 will change ev..</tspan>
       </text>
-      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="OpenSans, Open Sans" font-size="12">
+      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="12">
         <tspan x="12" y="48">The holy grail for any investor is to discover the next G...</tspan>
       </text>
-      <text fill="#46AEDA" mask="url(#l)" font-family="OpenSans-Semibold, Open Sans" font-size="14" font-weight="500">
+      <text fill="#46AEDA" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-weight="500">
         <tspan x="12" y="92">Next-level searching in Slack</tspan>
       </text>
-      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="OpenSans, Open Sans" font-size="12">
+      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="12">
         <tspan x="12" y="113">Day to day productivity is one thing. Having a long-ter...</tspan>
       </text>
-      <text fill="#46AEDA" mask="url(#l)" font-family="OpenSans-Semibold, Open Sans" font-size="14" font-weight="500">
+      <text fill="#46AEDA" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-weight="500">
         <tspan x="12" y="157">How Google Is Taking Search Outside the Box</tspan>
       </text>
-      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="OpenSans, Open Sans" font-size="12">
+      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="12">
         <tspan x="12" y="178">The I/O conference had virtual reality, photos and elec...</tspan>
       </text>
-      <text fill="#46AEDA" mask="url(#l)" font-family="OpenSans-Semibold, Open Sans" font-size="14" font-weight="500">
+      <text fill="#46AEDA" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-weight="500">
         <tspan x="12" y="222">A painstakingly crafted search for Hearthsto..</tspan>
       </text>
-      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="OpenSans, Open Sans" font-size="12">
+      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="12">
         <tspan x="12" y="243">Hearthstone’s popularity is stunning. Is it the worthy...</tspan>
       </text>
-      <text fill="#46AEDA" mask="url(#l)" font-family="OpenSans-Semibold, Open Sans" font-size="14" font-weight="500">
+      <text fill="#46AEDA" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-weight="500">
         <tspan x="12" y="287">A painstakingly crafted search for Hearthsto..</tspan>
       </text>
-      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="OpenSans, Open Sans" font-size="12">
+      <text fill="#262626" opacity=".5" mask="url(#l)" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="12">
         <tspan x="12" y="308">Hearthstone’s popularity is stunning. Is it the worthy...</tspan>
       </text>
-      <rect width="330" height="1" y="64" fill="#D8D8D8" opacity=".5" mask="url(#l)"/>
-      <rect width="330" height="1" y="129" fill="#D8D8D8" opacity=".5" mask="url(#l)"/>
-      <rect width="330" height="1" y="194" fill="#D8D8D8" opacity=".5" mask="url(#l)"/>
-      <rect width="330" height="1" y="259" fill="#D8D8D8" opacity=".5" mask="url(#l)"/>
+      <path fill="#D8D8D8" d="M0 64h330v1H0zm0 65h330v1H0zm0 65h330v1H0zm0 65h330v1H0z" opacity=".5" mask="url(#l)"/>
     </g>
-    <g transform="translate(0 16)">
-      <text fill="#262626" opacity=".5" font-family="OpenSans, Open Sans" font-size="12">
-        <tspan x="0" y="13">TYPE</tspan>
+    <text fill="#262626" opacity=".5" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="0" y="13">TYPE</tspan>
+    </text>
+    <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="20" y="43">Article</tspan>
+    </text>
+    <g transform="translate(0 49)">
+      <use fill="#3B99FC" stroke="url(#m)" mask="url(#n)" xlink:href="#b"/>
+      <use fill="#000" filter="url(#o)" xlink:href="#p"/>
+      <use stroke="#FFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" xlink:href="#p"/>
+    </g>
+    <g transform="translate(0 75)">
+      <use fill="#FFF" xlink:href="#c"/>
+      <use fill="#000" filter="url(#q)" xlink:href="#c"/>
+      <use stroke="url(#r)" mask="url(#s)" xlink:href="#c"/>
+    </g>
+    <g transform="translate(0 101)">
+      <use fill="#FFF" xlink:href="#d"/>
+      <use fill="#000" filter="url(#t)" xlink:href="#d"/>
+      <use stroke="url(#r)" mask="url(#u)" xlink:href="#d"/>
+    </g>
+    <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="20" y="69">Video</tspan>
+    </text>
+    <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="20" y="95">Categorie</tspan>
+    </text>
+    <text fill="#000" fill-opacity=".5" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="130.131" y="43">236</tspan>
+    </text>
+    <text fill="#000" fill-opacity=".5" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="136.421" y="69">48</tspan>
+    </text>
+    <text fill="#000" fill-opacity=".5" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 17)">
+      <tspan x="136.421" y="95">12</tspan>
+    </text>
+    <text fill="#262626" opacity=".5" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" transform="translate(0 146)">
+      <tspan x="0" y="13">TAGS</tspan>
+    </text>
+    <g transform="translate(0 175)">
+      <use stroke="#F0F0F0" stroke-width="2" mask="url(#v)" xlink:href="#e"/>
+      <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="13">
+        <tspan x="12" y="22">Startup</tspan>
       </text>
-      <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-        <tspan x="20" y="43">Article</tspan>
+    </g>
+    <g transform="translate(0 217)">
+      <use stroke="#F0F0F0" stroke-width="2" mask="url(#w)" xlink:href="#f"/>
+      <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="13">
+        <tspan x="12" y="22">Entrepreneurship</tspan>
       </text>
-      <g transform="translate(0 32)">
-        <use fill="#3B99FC" stroke="url(#m)" mask="url(#n)" xlink:href="#b"/>
-        <use fill="black" filter="url(#o)" xlink:href="#p"/>
-        <use stroke="#FFFFFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" xlink:href="#p"/>
-      </g>
-      <g transform="translate(0 58)">
-        <use fill="#FFFFFF" xlink:href="#c"/>
-        <use fill="black" filter="url(#q)" xlink:href="#c"/>
-        <use stroke="url(#r)" mask="url(#s)" xlink:href="#c"/>
-      </g>
-      <g transform="translate(0 84)">
-        <use fill="#FFFFFF" xlink:href="#d"/>
-        <use fill="black" filter="url(#t)" xlink:href="#d"/>
-        <use stroke="url(#r)" mask="url(#u)" xlink:href="#d"/>
-      </g>
-      <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-        <tspan x="20" y="69">Video</tspan>
+    </g>
+    <g transform="translate(0 259)">
+      <use stroke="#F0F0F0" stroke-width="2" mask="url(#x)" xlink:href="#g"/>
+      <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="13">
+        <tspan x="12" y="22">Search</tspan>
       </text>
-      <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-        <tspan x="20" y="95">Categorie</tspan>
+    </g>
+    <g transform="translate(73 259)">
+      <use stroke="#F0F0F0" stroke-width="2" mask="url(#y)" xlink:href="#h"/>
+      <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="13">
+        <tspan x="12" y="22">Design</tspan>
       </text>
-      <text fill="#000000" fill-opacity=".5" font-family="OpenSans, Open Sans" font-size="11">
-        <tspan x="130.131" y="43">236</tspan>
+    </g>
+    <g transform="translate(75 175)">
+      <use stroke="#F0F0F0" stroke-width="2" mask="url(#z)" xlink:href="#i"/>
+      <text fill="#262626" font-family="'Open Sans', Open Sans, OpenSans, sans-serif" font-size="13">
+        <tspan x="12" y="22">Marketing</tspan>
       </text>
-      <text fill="#000000" fill-opacity=".5" font-family="OpenSans, Open Sans" font-size="11">
-        <tspan x="136.421" y="69">48</tspan>
-      </text>
-      <text fill="#000000" fill-opacity=".5" font-family="OpenSans, Open Sans" font-size="11">
-        <tspan x="136.421" y="95">12</tspan>
-      </text>
-      <g transform="translate(0 129)">
-        <text fill="#262626" opacity=".5" font-family="OpenSans, Open Sans" font-size="12">
-          <tspan x="0" y="13">TAGS</tspan>
-        </text>
-        <g transform="translate(0 29)">
-          <use stroke="#F0F0F0" stroke-width="2" mask="url(#v)" xlink:href="#e"/>
-          <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-            <tspan x="12" y="22">Startup</tspan>
-          </text>
-        </g>
-        <g transform="translate(0 71)">
-          <use stroke="#F0F0F0" stroke-width="2" mask="url(#w)" xlink:href="#f"/>
-          <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-            <tspan x="12" y="22">Entrepreneurship</tspan>
-          </text>
-        </g>
-        <g transform="translate(0 113)">
-          <use stroke="#F0F0F0" stroke-width="2" mask="url(#x)" xlink:href="#g"/>
-          <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-            <tspan x="12" y="22">Search</tspan>
-          </text>
-        </g>
-        <g transform="translate(73 113)">
-          <use stroke="#F0F0F0" stroke-width="2" mask="url(#y)" xlink:href="#h"/>
-          <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-            <tspan x="12" y="22">Design</tspan>
-          </text>
-        </g>
-        <g transform="translate(75 29)">
-          <use stroke="#F0F0F0" stroke-width="2" mask="url(#z)" xlink:href="#i"/>
-          <text fill="#262626" font-family="OpenSans, Open Sans" font-size="13">
-            <tspan x="12" y="22">Marketing</tspan>
-          </text>
-        </g>
-      </g>
     </g>
   </g>
 </svg>


### PR DESCRIPTION
This image didn't have any fallback font for when Open Sans isn't loaded/installed, there should be a fallback font

this is also fixed by using outlines

feel free to close if you decide to use another strategy