### PR TITLE
Register plugin scripts to be enqueued to the footer

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -238,15 +238,15 @@ class Algolia_Plugin {
 		wp_register_style( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../assets/css/algolia-instantsearch.css', array(), ALGOLIA_VERSION, 'screen' );
 
 		// JS.
-		wp_register_script( 'algolia-search', plugin_dir_url( __FILE__ ) . '../assets/js/algoliasearch/algoliasearch.jquery'.$suffix.'.js', array( 'jquery' ), ALGOLIA_VERSION );
-		wp_register_script( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../assets/js/autocomplete.js/autocomplete'.$suffix.'.js', array(), ALGOLIA_VERSION );
-		wp_register_script( 'algolia-autocomplete-noconflict', plugin_dir_url( __FILE__ ) . '../assets/js/autocomplete-noconflict.js', array(), ALGOLIA_VERSION );
-		
-		
-		wp_register_script( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../assets/js/instantsearch.js/instantsearch-preact'.$suffix.'.js', array(), ALGOLIA_VERSION );
+		wp_register_script( 'algolia-search', plugin_dir_url( __FILE__ ) . '../assets/js/algoliasearch/algoliasearch.jquery'.$suffix.'.js', array( 'jquery' ), ALGOLIA_VERSION, true );
+		wp_register_script( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../assets/js/autocomplete.js/autocomplete'.$suffix.'.js', array(), ALGOLIA_VERSION, true );
+		wp_register_script( 'algolia-autocomplete-noconflict', plugin_dir_url( __FILE__ ) . '../assets/js/autocomplete-noconflict.js', array(), ALGOLIA_VERSION, true );
+
+
+		wp_register_script( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../assets/js/instantsearch.js/instantsearch-preact'.$suffix.'.js', array(), ALGOLIA_VERSION, true );
 
 		// Vendor JS.
-		wp_register_script( 'tether', plugin_dir_url( __FILE__ ) . '../assets/js/tether/tether'.$suffix.'.js', array(), ALGOLIA_VERSION );
+		wp_register_script( 'tether', plugin_dir_url( __FILE__ ) . '../assets/js/tether/tether'.$suffix.'.js', array(), ALGOLIA_VERSION, true );
 	}
 
 	/**

--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -24,10 +24,10 @@ class Algolia_Template_Loader {
 		// Load autocomplete.js search experience if its enabled.
 		if ( $this->should_load_autocomplete() ) {
 			add_filter( 'wp_enqueue_scripts', array( $this, 'enqueue_autocomplete_scripts' ) );
-			add_filter( 'wp_footer', array( $this, 'load_autocomplete_template' ) );
+			add_filter( 'wp_footer', array( $this, 'load_autocomplete_template' ), PHP_INT_MAX );
 		}
 	}
-	
+
 	public function load_algolia_config() {
 		$settings = $this->plugin->get_settings();
 		$autocomplete_config = $this->plugin->get_autocomplete_config();
@@ -57,7 +57,7 @@ class Algolia_Template_Loader {
 
 		echo '<script type="text/javascript">var algolia = ' . $json_config . '</script>';
 	}
-	
+
 	private function should_load_autocomplete() {
 		$settings = $this->plugin->get_settings();
 		$autocomplete = $this->plugin->get_autocomplete_config();
@@ -165,13 +165,13 @@ class Algolia_Template_Loader {
 		if ( 'algolia/' !== $templates_path ) {
 			$locations[] = 'algolia/' . $file;
 		}
-		
+
 		$locations[] = $templates_path . $file;
 
 		$locations = (array) apply_filters( 'algolia_template_locations', $locations, $file );
 
 		$template = locate_template( array_unique( $locations ) );
-		
+
 		$default_template = (string) apply_filters( 'algolia_default_template', $this->plugin->get_path() . '/templates/' . $file, $file );
 
 		return $template ? $template : $default_template;


### PR DESCRIPTION
Currently plugin scripts are enqueued to the head. This PR adds `$in_footer` argument to the [wp_enqueue_script](https://developer.wordpress.org/reference/functions/wp_enqueue_script/) function, so scripts will be included before `</body>`.

Also makes sure that `autocomplete.php` file will be echo out after plugin scripts.