### PR TITLE
feat(indexing): add a filter to customize object ids

### DIFF
--- a/docs/src/frequently-asked-questions.md
+++ b/docs/src/frequently-asked-questions.md
@@ -119,6 +119,34 @@ function custom_user_record( array $record, WP_User $user ) {
 add_filter( 'algolia_user_record', 'custom_user_record', 10, 2 );
 ```
 
-### My case is not listed here, what to do?
+### Can I display results coming from multiple websites?
 
-If your problem is covered here, please submit an issue with the error details here: https://github.com/algolia/algoliasearch-wordpress/issues
+Yes, but only if all those those websites are WordPress websites using this plugin.
+
+In that case, you need to:
+
+1. Customize the object ids to make them unique across the different websites
+1. Configure both websites to use the same index prefix
+1. Re-index all indices from all websites
+
+**Warning: this has no impact on Algolia used in the backend given that you can only load posts that are available in the current database.**
+
+Here is an example on how to customize the object ids:
+
+```php
+// To be added to the functions.php file of your active theme.
+// Can also be shipped into a custom plugin.
+function scope_object_id_to_current_website( $object_id ) {
+  return 'mywebsite.com_' . $object_id;
+}
+
+add_filter( 'algolia_get_post_object_id', 'scope_object_id_to_current_website' );
+add_filter( 'algolia_get_term_object_id', 'scope_object_id_to_current_website' );
+add_filter( 'algolia_get_user_object_id', 'scope_object_id_to_current_website' );
+```
+
+This code will prefix all object IDs so that records originating from different indices do not conflict.
+
+### Your question remains unanswered
+
+If your question is not covered by this FAQ page, please [open an issue](https://github.com/algolia/algoliasearch-wordpress/issues).

--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -223,7 +223,7 @@ abstract class Algolia_Index
 		}
 	}
 
-	public function create_index_if_not_existing( $clear_if_existing = true )
+	public function create_index_if_not_existing()
     {
         $index = $this->get_index();
 
@@ -235,11 +235,6 @@ abstract class Algolia_Index
         }
 
 	    if ( $index_exists === true ) {
-
-		    if ( $clear_if_existing === true ) {
-			    $index->clearIndex();
-		    }
-
 		    $force_settings_update = (bool) apply_filters( 'algolia_should_force_settings_update', false, $this->get_id() );
 		    if ( $force_settings_update === false ) {
 			    // No need to go further in this case.

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -254,7 +254,9 @@ final class Algolia_Posts_Index extends Algolia_Index
 	 * @return string
 	 */
 	private function get_post_object_id( $post_id, $record_index ) {
-		return $post_id . '-' . $record_index;
+	    $object_id = $post_id . '-' . $record_index;
+
+		return apply_filters( 'algolia_get_post_object_id', $object_id, $post_id, $record_index );
 	}
 
 	/**

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -82,7 +82,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index
         $parts = Algolia_Utils::explode_content( $post_content );
 
         if ( defined( 'ALGOLIA_SPLIT_POSTS' ) && false === ALGOLIA_SPLIT_POSTS ) {
-            $parts = array_shift( $parts );
+            $parts = array( array_shift( $parts ) );
         }
 
         $records = array();

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -238,7 +238,9 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index
 	 * @return string
 	 */
 	private function get_post_object_id( $post_id, $record_index ) {
-		return $post_id . '-' . $record_index;
+        $object_id = $post_id . '-' . $record_index;
+
+        return apply_filters( 'algolia_get_post_object_id', $object_id, $post_id, $record_index );
 	}
 
 	/**

--- a/includes/indices/class-algolia-terms-index.php
+++ b/includes/indices/class-algolia-terms-index.php
@@ -53,7 +53,7 @@ final class Algolia_Terms_Index extends Algolia_Index
 	protected function get_records( $item )
 	{
 		$record = array();
-		$record['objectID'] = $item->term_id;
+		$record['objectID'] = apply_filters( 'algolia_get_term_object_id', $item->term_id, $item->term_id );
 		$record['term_id'] = $item->term_id;
 		$record['taxonomy'] = $item->taxonomy;
 		$record['name'] = $item->name;

--- a/includes/indices/class-algolia-users-index.php
+++ b/includes/indices/class-algolia-users-index.php
@@ -39,7 +39,7 @@ final class Algolia_Users_Index extends Algolia_Index
 	protected function get_records( $item )
 	{
 		$record = array();
-		$record['objectID'] = $item->ID;
+		$record['objectID'] = apply_filters( 'algolia_get_user_object_id', $item->ID, $item->ID );
 		$record['user_id'] = $item->ID;
 		$record['display_name'] = $item->display_name;
 		$record['posts_url'] = get_author_posts_url( $item->ID, $item->user_nicename );


### PR DESCRIPTION
This PR will allow to customize the object IDs generation.

The main objective being to allow users to store posts comming from different websites in the same index.

Requirements:
- Change the object ID based on a custom detection rule (will document)
- Disable index clearing on first page (needs an additional commit. currently unsupported)
- Use the same index prefix in both websites
- Not use Algolia in the backend, or filter based on a numeric value