### PR TITLE
Disable WordPress object cache on post count WP_Query call

### DIFF
--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -299,10 +299,12 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index
 	 */
 	protected function get_re_index_items_count() {
 		$query = new WP_Query( array(
-			'post_type'   		    => $this->post_types,
-			'post_status' 		    => 'any', // Let the `should_index` take care of the filtering.
-			'suppress_filters'      => true,
-			'cache_results'  		=> false
+			'post_type'   		    	=> $this->post_types,
+			'post_status' 		    	=> 'any', // Let the `should_index` take care of the filtering.
+			'suppress_filters'      	=> true,
+			'cache_results'  			=> false,
+	        'lazy_load_term_meta'   	=> false,
+      		'update_post_term_cache' 	=> false
 		) );
 		
 		return (int) $query->found_posts;
@@ -316,13 +318,16 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index
 	 */
 	protected function get_items( $page, $batch_size ) {
 		$query = new WP_Query( array(
-			'post_type'      	  => $this->post_types,
-			'posts_per_page' 	  => $batch_size,
-			'post_status'    	  => 'any',
-			'order'          	  => 'ASC',
-			'orderby'        	  => 'ID',
-			'paged'			 	  => $page,
-			'suppress_filters' 	  => true,
+			'post_type'      	  		=> $this->post_types,
+			'posts_per_page' 	  		=> $batch_size,
+			'post_status'    	  		=> 'any',
+			'order'          	  		=> 'ASC',
+			'orderby'        	  		=> 'ID',
+			'paged'			 	  		=> $page,
+			'suppress_filters' 	  		=> true,
+			'cache_results'  			=> false,
+	        'lazy_load_term_meta'   	=> false,
+      		'update_post_term_cache' 	=> false
 		) );
 
 		return $query->posts;

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -302,6 +302,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index
 			'post_type'   		    => $this->post_types,
 			'post_status' 		    => 'any', // Let the `should_index` take care of the filtering.
 			'suppress_filters'      => true,
+			'cache_results'  		=> false
 		) );
 		
 		return (int) $query->found_posts;


### PR DESCRIPTION
We were receiving a PHP error regarding the memory size exhausted when attempting to run a full reindex (of a large database, over 5000 posts and hundreds of taxonomies). This error occurred when running this function both through the WP admin as well as wp-cli. 

We limited the number of synchronous indexes using the `algolia_indexing_batch_size` filter as suggested, even setting that to 1, but still received the error. We also noticed the error always occurred almost immediately after starting the reindex. 

After some PHP debugging, we found the function was crashing at line 30 of WordPress core file `cache.php`. This was the result of the Algolia function `get_re_index_items_count`. So it was exhausting memory just trying to count the posts. 

I’m not sure, but it didn’t seem necessary or even helpful (?) to cache the results during a reindex. So we disabled the WordPress object caching in the WP Query call of the above function:

```php
		$query = new WP_Query( array(
			'post_type'   		    => $this->post_types,
			'post_status' 		    => 'any', // Let the `should_index` take care of the filtering.
			'suppress_filters'      => true,
			'cache_results'  => false
		) );
```

This fixed the error and the indexing ran without a problem. 

There's another WP_Query call in that file to get the actual posts. For some reason this doesn't cause a memory error, but maybe it makes sense to disable cache there as well?

Hoping that this can be incorporated into the code so that we don’t have to use a modified version of the plugin with this line.

Thanks!