### PR TITLE
Adding a hook for removing tags from content

### DIFF
--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -44,50 +44,49 @@ This will also disable tasks being generated for that content type.
 
 Here is the list of all available Filters.
 
-| Filter Name                                              | Params                                                                           |
-|:---------------------------------------------------------|:---------------------------------------------------------------------------------|
-| algolia_autocomplete_config                              | $config                                                                          |
-| algolia_autocomplete_input_selector                      | string $input_selector, defaults to "input[name='s']:not('.no-autocomplete')"    |
-| algolia_post_types_blacklist                             | array $blacklist, defaults to array( 'nav_menu_item', revision' )                |
-| algolia_taxonomies_blacklist                             | array $blacklist, defaults to array( 'nav_menu', link_category', 'post_format' ) |
-| algolia_should_index_searchable_post                     | bool $should_index, WP_Post $post                                                |
-| algolia_searchable_post_parser                           | Algolia\DOMParser $parser                                                        |
-| algolia_searchable\_post\_{$post_type}_shared_attributes | array $shared_attributes, WP_Post $post                                          |
-| algolia_searchable_posts_index_settings                  | array $settings                                                                  |
-| algolia_searchable_post_shared_attributes                | array $shared_attributes, WP_Post $post                                          |
-| algolia_searchable_posts_index_synonyms                  | array $synonyms                                                                  |
-| algolia_should_force_settings_update                     | bool $should_force_update (default: false), string $index_id                     |
-| algolia_should_index_post                                | bool $should_index, WP_Post $post                                                |
-| algolia_post_parser                                      | Algolia\DOMParser $parser                                                        |
-| algolia_post_shared_attributes                           | array $shared_attributes, WP_Post $post                                          |
-| algolia\_post\_{$post_type}_shared_attributes            | array $shared_attributes, WP_Post $post                                          |
-| algolia_posts_index_settings                             | array $settings, string $post_type                                               |
-| algolia\_posts\_{$post_type}_index_settings              | array $settings                                                                  |
-| algolia_posts_index_synonyms                             | array $synonyms, string $post_type                                               |
-| algolia\_posts\_{$post_type}_index_synonyms              | array $synonyms                                                                  |
-| algolia_should_index_term                                | bool $should_index, WP_Term/object $term                                         |
-| algolia_term_record                                      | array $record, WP_Term/object$term                                               |
-| algolia\_term\_{$taxonomy}_record                        | array $record, WP_Term/object $term                                              |
-| algolia_terms_index_settings                             | array $settings                                                                  |
-| algolia\_terms\_{$taxonomy}_index_settings               | array $settings                                                                  |
-| algolia_terms_index_synonyms                             | array $synonyms, string $taxonomy                                                |
-| algolia\_terms\_{$taxonomy}_index_synonyms               | array $synonyms                                                                  |
-| algolia_should_index_user                                | bool $should_index, WP_User $user                                                |
-| algolia_user_record                                      | array $record, WP_User $user                                                     |
-| algolia_users_index_settings                             | array $settings                                                                  |
-| algolia_users_index_synonyms                             | array $synonyms                                                                  |
-| algolia_index_replicas                                   | array $replicas, Algolia_Index $index                                            |
-| algolia\_{$index_id}_index_replicas                      | array $replicas, Algolia_Index $index                                            |
-| algolia_config                                           | array $config                                                                    |
-| algolia_indexing_batch_size                              | int $batch_size (default: 100)                                                   |
-| algolia\_{$index_id}_indexing_batch_size                 | int $batch_size                                                                  |
-| algolia_templates_path                                   | string $path (default: 'algolia/')                                               |
-| algolia_template_locations                               | array $locations                                                                 |
-| algolia_default_template                                 | string $template, string $file                                                   |
-| algolia_search_params                                    | array $params                                                                    |
-| algolia_search_order_by                                  | string $attribute_name                                                           |
-| algolia_search_order                                     | string $order                                                                    |
-| algolia_should_override_search_with_instantsearch        | bool $bool (default: depending on configuration)                                 |
-| algolia_post_images_sizes                                | array $sizes (default: only the 'thumbnail' size)                                |
-| algolia_get_post_images                                  | array $images (default: only the info about the 'thumbnail' size)                |
-| algolia_get_synced_indices_ids                           | array $ids                                                                       |
+| Filter Name                                              | Params                                                                                                      |
+|:---------------------------------------------------------|:------------------------------------------------------------------------------------------------------------|
+| algolia_autocomplete_config                              | $config                                                                                                     |
+| algolia_autocomplete_input_selector                      | string $input_selector, defaults to "input[name='s']:not('.no-autocomplete')"                               |
+| algolia_post_types_blacklist                             | array $blacklist, defaults to array( 'nav_menu_item', revision' )                                           |
+| algolia_taxonomies_blacklist                             | array $blacklist, defaults to array( 'nav_menu', link_category', 'post_format' )                            |
+| algolia_should_index_searchable_post                     | bool $should_index, WP_Post $post                                                                           |
+| algolia_searchable\_post\_{$post_type}_shared_attributes | array $shared_attributes, WP_Post $post                                                                     |
+| algolia_searchable_posts_index_settings                  | array $settings                                                                                             |
+| algolia_searchable_post_shared_attributes                | array $shared_attributes, WP_Post $post                                                                     |
+| algolia_searchable_posts_index_synonyms                  | array $synonyms                                                                                             |
+| algolia_should_force_settings_update                     | bool $should_force_update (default: false), string $index_id                                                |
+| algolia_should_index_post                                | bool $should_index, WP_Post $post                                                                           |
+| algolia_post_shared_attributes                           | array $shared_attributes, WP_Post $post                                                                     |
+| algolia\_post\_{$post_type}_shared_attributes            | array $shared_attributes, WP_Post $post                                                                     |
+| algolia_posts_index_settings                             | array $settings, string $post_type                                                                          |
+| algolia\_posts\_{$post_type}_index_settings              | array $settings                                                                                             |
+| algolia_posts_index_synonyms                             | array $synonyms, string $post_type                                                                          |
+| algolia\_posts\_{$post_type}_index_synonyms              | array $synonyms                                                                                             |
+| algolia_should_index_term                                | bool $should_index, WP_Term/object $term                                                                    |
+| algolia_term_record                                      | array $record, WP_Term/object$term                                                                          |
+| algolia\_term\_{$taxonomy}_record                        | array $record, WP_Term/object $term                                                                         |
+| algolia_terms_index_settings                             | array $settings                                                                                             |
+| algolia\_terms\_{$taxonomy}_index_settings               | array $settings                                                                                             |
+| algolia_terms_index_synonyms                             | array $synonyms, string $taxonomy                                                                           |
+| algolia\_terms\_{$taxonomy}_index_synonyms               | array $synonyms                                                                                             |
+| algolia_should_index_user                                | bool $should_index, WP_User $user                                                                           |
+| algolia_user_record                                      | array $record, WP_User $user                                                                                |
+| algolia_users_index_settings                             | array $settings                                                                                             |
+| algolia_users_index_synonyms                             | array $synonyms                                                                                             |
+| algolia_index_replicas                                   | array $replicas, Algolia_Index $index                                                                       |
+| algolia\_{$index_id}_index_replicas                      | array $replicas, Algolia_Index $index                                                                       |
+| algolia_config                                           | array $config                                                                                               |
+| algolia_indexing_batch_size                              | int $batch_size (default: 100)                                                                              |
+| algolia\_{$index_id}_indexing_batch_size                 | int $batch_size                                                                                             |
+| algolia_templates_path                                   | string $path (default: 'algolia/')                                                                          |
+| algolia_template_locations                               | array $locations                                                                                            |
+| algolia_default_template                                 | string $template, string $file                                                                              |
+| algolia_search_params                                    | array $params                                                                                               |
+| algolia_search_order_by                                  | string $attribute_name                                                                                      |
+| algolia_search_order                                     | string $order                                                                                               |
+| algolia_should_override_search_with_instantsearch        | bool $bool (default: depending on configuration)                                                            |
+| algolia_post_images_sizes                                | array $sizes (default: only the 'thumbnail' size)                                                           |
+| algolia_get_post_images                                  | array $images (default: only the info about the 'thumbnail' size)                                           |
+| algolia_get_synced_indices_ids                           | array $ids                                                                                                  |
+| algolia_strip_patterns                                   | array $noise_patterns (default: regular expressions to strip comments, cdata, script, style, code, and pre) | 

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -171,7 +171,7 @@ class Algolia_Utils
     }
 
     public static function remove_content_noise( $content ) {
-	    $noise_patterns = (array) apply_filters( 'algolia_strip_patterns', array(
+	    $noise_patterns = array(
             // strip out comments.
             "'<!--(.*?)-->'is",
             // strip out cdata.
@@ -189,12 +189,14 @@ class Algolia_Utils
             // strip out <pre> tags.
             "'<\s*pre[^>]*[^/]>(.*?)<\s*/\s*pre\s*>'is",
             "'<\s*pre\s*>(.*?)<\s*/\s*pre\s*>'is",
-        ) );
+        );
 
         // If there is ET builder (Divi), remove shortcodes.
         if ( function_exists( 'et_pb_is_pagebuilder_used' ) ) {
             $noise_patterns[] = '/\[\/?et_pb.*?\]/';
         }
+
+        $noise_patterns = (array) apply_filters( 'algolia_strip_patterns', $noise_patterns );
 
 	    foreach ( $noise_patterns as $pattern ) {
 	        $content = preg_replace( $pattern, '', $content );

--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -171,7 +171,7 @@ class Algolia_Utils
     }
 
     public static function remove_content_noise( $content ) {
-	    $noise_patterns = array(
+	    $noise_patterns = (array) apply_filters( 'algolia_strip_patterns', array(
             // strip out comments.
             "'<!--(.*?)-->'is",
             // strip out cdata.
@@ -189,7 +189,7 @@ class Algolia_Utils
             // strip out <pre> tags.
             "'<\s*pre[^>]*[^/]>(.*?)<\s*/\s*pre\s*>'is",
             "'<\s*pre\s*>(.*?)<\s*/\s*pre\s*>'is",
-        );
+        ) );
 
         // If there is ET builder (Divi), remove shortcodes.
         if ( function_exists( 'et_pb_is_pagebuilder_used' ) ) {


### PR DESCRIPTION
This PR removes a couple of outdated filters from the `filters.md` doc and adds a filter to modify the array of regular expressions that strip tags from the content when indexing.

See #640 for more.