### PR TITLE
Add minimum required PHP version to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Tags:** Search, Algolia, Autocomplete, instant-search, relevant search, search highlight, faceted search, find-as-you-type search, suggest, search by category, ajax search, better search, custom search  
 **Requires at least:** 4.4  
 **Tested up to:** 4.8  
+**Requires PHP:** 5.3  
 **Stable tag:** 2.7.0  
 **License:** MIT License, GNU General Public License v2.0  
 

--- a/README.txt
+++ b/README.txt
@@ -3,6 +3,7 @@ Contributors: algolia, rayrutjes
 Tags: Search, Algolia, Autocomplete, instant-search, relevant search, search highlight, faceted search, find-as-you-type search, suggest, search by category, ajax search, better search, custom search
 Requires at least: 4.4
 Tested up to: 4.8
+Requires PHP: 5.3
 Stable tag: 2.7.0
 License: MIT License, GNU General Public License v2.0
 


### PR DESCRIPTION
Last month WP.org introduced support for this [feature](https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/). Currently it just displays information on plugins page, but in future it will prevent users installing plugin, if they are running old PHP versions.