### PR TITLE
RFC (algolia_post_content) Pass post object to callback

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -89,7 +89,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 
 		$removed = remove_filter( 'the_content', 'wptexturize', 10 );
 
-		$post_content = apply_filters( 'algolia_post_content', $post->post_content );
+		$post_content = apply_filters( 'algolia_post_content', $post );
 		$post_content = apply_filters( 'the_content', $post_content );
 
 		if ( true === $removed ) {

--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -89,7 +89,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 
 		$removed = remove_filter( 'the_content', 'wptexturize', 10 );
 
-		$post_content = apply_filters( 'algolia_post_content', $post );
+		$post_content = apply_filters( 'algolia_post_content', $post->post_content, $post );
 		$post_content = apply_filters( 'the_content', $post_content );
 
 		if ( true === $removed ) {

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -79,7 +79,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 
 		$removed = remove_filter( 'the_content', 'wptexturize', 10 );
 
-		$post_content = apply_filters( 'algolia_searchable_post_content', $post );
+		$post_content = apply_filters( 'algolia_searchable_post_content', $post->post_content, $post );
 		$post_content = apply_filters( 'the_content', $post_content );
 
 		if ( true === $removed ) {

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -79,7 +79,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 
 		$removed = remove_filter( 'the_content', 'wptexturize', 10 );
 
-		$post_content = apply_filters( 'algolia_searchable_post_content', $post->post_content );
+		$post_content = apply_filters( 'algolia_searchable_post_content', $post );
 		$post_content = apply_filters( 'the_content', $post_content );
 
 		if ( true === $removed ) {


### PR DESCRIPTION
I started a discussion about this here: #718

Basically, I feel like having the `algolia_post_content` filters use the post content as a callback does nothing for the user (at least not for me, but I don't see many use cases that would benefit from the current form). 

It's much harder to use any other property of the post when all you have is the post content, but it's easy to just use `$post->post_content` once you have the post object, so this would seem like a pretty clear win. I'm not even sure how the current signature would work - am I supposed to use global state?

Otherwise, can you please help me find a better solution? 

I also know that this is not backwards compatible - if there's a special deprecation process in place please let me know so I can update accordingly. 

Unfortunately this one functionality probably means I'll have to mirror the plugin or something until we get a better option in production. Any help is appreciated, thanks.