### PR TITLE
fix: do not escape query passed to frontend

### DIFF
--- a/includes/class-algolia-template-loader.php
+++ b/includes/class-algolia-template-loader.php
@@ -37,7 +37,7 @@ class Algolia_Template_Loader {
 			'application_id'     => $settings->get_application_id(),
 			'search_api_key'     => $settings->get_search_api_key(),
 			'powered_by_enabled' => $settings->is_powered_by_enabled(),
-			'query'              => isset( $_GET['s'] ) ? esc_html( $_GET['s'] ) : '',
+			'query'              => isset( $_GET['s'] ) ? $_GET['s'] : '',
 			'autocomplete'       => array(
 				'sources'        => $autocomplete_config->get_config(),
 				'input_selector' => (string) apply_filters( 'algolia_autocomplete_input_selector', "input[name='s']:not('.no-autocomplete')" ),


### PR DESCRIPTION
The query retrieved in the URL is potentially used as input value.
Escaping the HTML is not expected here as it makes the value unusable for that purpose.
In other places where used, the query is already escaped.

Closes: #734