### PR TITLE
Filter indexed meta keys before triggering a sync

### DIFF
--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -77,7 +77,10 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @param string       $meta_key
 	 */
 	public function on_meta_change( $meta_id, $object_id, $meta_key ) {
-		if ( '_thumbnail_id' !== $meta_key ) {
+		$keys = array( '_thumbnail_id' );
+		$keys = (array) apply_filters( 'algolia_watch_post_meta_keys', $keys, $object_id );
+
+		if ( !in_array( $meta_key, $keys ) ) {
 			return;
 		}
 


### PR DESCRIPTION
When adding custom shared_attributes with the algolia_searchable_post_shared_attributes filter for example, it can occur that these attributes aren't synced properly the first time the post is saved. We've seen this happen on attributes that are based on post_meta. 
In this PR I've added a filter which lets us change the meta keys on which an update is triggered.  