### PR TITLE
Remove php version since it's part of the client 1.26.0

### DIFF
--- a/includes/class-algolia-api.php
+++ b/includes/class-algolia-api.php
@@ -50,7 +50,6 @@ class Algolia_API {
 
 		// Build the UserAgent.
 		$ua = '; ' . $integration_name . ' integration (' . $integration_version . ')'
-			. '; PHP (' . phpversion() . ')'
 			. '; WordPress (' . $wp_version . ')';
 
 		Version::$custom_value = $ua;


### PR DESCRIPTION
This PR should be merged when the api client dependency is updated to 1.25.0 (see https://github.com/algolia/algoliasearch-client-php/pull/392)