### PR TITLE
Fix should_index_post()

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -52,7 +52,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 		$post_status = $post->post_status;
 
 		if ( 'inherit' === $post_status ) {
-			$parent_post = get_post( $post->post_parent );
+			$parent_post = ( $post->post_parent ) ? get_post( $post->post_parent ) : null;
 			if ( null !== $parent_post ) {
 				$post_status = $parent_post->post_status;
 			} else {


### PR DESCRIPTION
I recently find a bug when updating an media attachment that was not linked to a page or a post. Updating the attachment was making it disappear from the algolia indice. By digging the problem, I found that the following line of the function should_index_post() in the file includes/indicesclass-algolia-posts-index.php was causing the bug: $parent_post = get_post( $post->post_parent ).

In the case of an media attachment that is not linked to a page or a post, post->post_parent is equal to 0 and calling the function get_post() with a value of 0 will not return null as expected. Instead, the function will return the same post ID of the current post when it's not finding any result. This is why I suggest to change the line to: $parent_post = ( $post->post_parent ) ? get_post( $post->post_parent ) : null.