### PR TITLE
fix: decode HTML entities before sending them to Algolia

### DIFF
--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -151,7 +151,7 @@ class Algolia_Utils {
 			$content = preg_replace( $pattern, '', $content );
 		}
 
-		return $content;
+		return html_entity_decode( $content );
 	}
 
 	/**


### PR DESCRIPTION
This commit will decode HTML entities for the post content attribute before sending it to Algolia.
This ensures we do not end up displaying things like `&amp;`.

This issue arises now because we properly escape the content in the frontend directly.

The solution is to store the decoded HTML in Algolia and let the frontend handle the escaping.

In order to benefit from this fix, you should re-index everything.

You can also choose to cherry pick and  update the posts having an encoded char displayed.

**Test plan:**

The fix has manually been tested by adding `&` in the post editor.
This would turn the symbol into `&amp;` but stores it as `&` in Algolia.

To be sure, I also tried to inject JS directly from adding script tags to an Algolia record.
They are properly escaped at run time.

Closes: #656