### PR TITLE
Pass posts per page from filtered params

### DIFF
--- a/includes/class-algolia-search.php
+++ b/includes/class-algolia-search.php
@@ -89,7 +89,7 @@ class Algolia_Search {
 			$post_ids = array( 0 );
 		}
 
-		$query->set( 'posts_per_page', $posts_per_page );
+		$query->set( 'posts_per_page', $params['hitsPerPage'] );
 		$query->set( 'offset', 0 );
 
 		$post_types = 'any';


### PR DESCRIPTION
If the `$posts_per_page` are updated through the `algolia_search_params` filter, that value is not returned in the local query.