### PR TITLE
added filter for algolia_should_require_search_client

### DIFF
--- a/classmap.php
+++ b/classmap.php
@@ -5,7 +5,9 @@ if ( ! defined( 'ALGOLIA_PATH' ) ) {
 }
 
 // The Algolia Search PHP API Client.
-require_once ALGOLIA_PATH . 'includes/libraries/algoliasearch-client-php/algoliasearch.php';
+if ( apply_filters( 'algolia_should_require_search_client', true ) ) {
+	require_once ALGOLIA_PATH . 'includes/libraries/algoliasearch-client-php/algoliasearch.php';
+}
 
 require_once ALGOLIA_PATH . 'includes/class-algolia-api.php';
 require_once ALGOLIA_PATH . 'includes/class-algolia-autocomplete-config.php';

--- a/docs/src/filters.md
+++ b/docs/src/filters.md
@@ -96,3 +96,4 @@ Here is the list of all available Filters.
 | algolia_strip_patterns                                   | array $noise_patterns (default: regular expressions to strip comments, cdata, script, style, code, and pre) |
 | algolia_searchable_post_types                            | array $post_types                                                                                           |
 | algolia_native_search_index_id                           | string $index_id                                                                                            |
+| algolia_should_require_search_client                     | bool $bool, (default: true, loads the included Algolia search client library)                               |


### PR DESCRIPTION
This covers the issue raised in #781 to allow developers to filter the loading of the search client library.