### PR TITLE
fix: avoid 'screen' media attribute

### DIFF
--- a/includes/class-algolia-plugin.php
+++ b/includes/class-algolia-plugin.php
@@ -152,8 +152,8 @@ class Algolia_Plugin {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		// CSS.
-		wp_register_style( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../css/algolia-autocomplete.css', array(), ALGOLIA_VERSION, 'screen' );
-		wp_register_style( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../css/algolia-instantsearch.css', array(), ALGOLIA_VERSION, 'screen' );
+		wp_register_style( 'algolia-autocomplete', plugin_dir_url( __FILE__ ) . '../css/algolia-autocomplete.css', array(), ALGOLIA_VERSION );
+		wp_register_style( 'algolia-instantsearch', plugin_dir_url( __FILE__ ) . '../css/algolia-instantsearch.css', array(), ALGOLIA_VERSION );
 
 		// JS.
 		wp_register_script( 'algolia-search', plugin_dir_url( __FILE__ ) . '../js/algoliasearch/algoliasearch.jquery' . $suffix . '.js', array( 'jquery', 'underscore', 'wp-util' ), ALGOLIA_VERSION );


### PR DESCRIPTION
This causes most WordPress optimizer plugins honor the `screen` media attribute and generate a separate CSS for it. We can simple uses `all` (default) since we don't have `handheld` or `print` define.

A more details about this issue can be found at https://blog.futtta.be/2016/10/04/how-to-fix-css-media-types-impacting-autoptimized-css-order/