### PR TITLE
bugfix: fix searching persian words problem

### DIFF
--- a/includes/class-algolia-search.php
+++ b/includes/class-algolia-search.php
@@ -63,7 +63,7 @@ class Algolia_Search {
 		$order    = apply_filters( 'algolia_search_order', 'desc' );
 
 		try {
-			$results = $this->index->search( $query->query['s'], $params, $order_by, $order );
+			$results = $this->index->search( urldecode($query->query['s']), $params, $order_by, $order );
 		} catch ( \AlgoliaSearch\AlgoliaException $exception ) {
 			error_log( $exception->getMessage() );
 


### PR DESCRIPTION
There was a problem with searching persian words. Because of urlencode function words like "اپل" or "سلام" didn't return any results.
Fixed it by just adding a urldecode function before calling API.