### PR TITLE
feat: add algolia_should_filter_query filter

### DIFF
--- a/includes/class-algolia-search.php
+++ b/includes/class-algolia-search.php
@@ -29,7 +29,9 @@ class Algolia_Search {
 	 * @return bool
 	 */
 	private function should_filter_query( WP_Query $query ) {
-		return ! $query->is_admin && $query->is_search() && $query->is_main_query();
+		$should_filter = ! $query->is_admin && $query->is_search() && $query->is_main_query();
+		
+		return (bool) apply_filters( 'algolia_should_filter_query', $should_filter, $query );
 	}
 
 	/**


### PR DESCRIPTION
This filter allows developers to turn on or of Algolia wherever they want. For instance in custom archive-searches with custom filters. Can be used to implement simple filter functions on WordPress native search. Implementations like this may not be compatible with Algolia by default.

Discussion were made in previous proposed pull-request: https://github.com/algolia/algoliasearch-wordpress/pull/750 