### PR TITLE
feat: add algolia_clear_index_if_existing filter

### DIFF
--- a/includes/indices/class-algolia-index.php
+++ b/includes/indices/class-algolia-index.php
@@ -277,6 +277,7 @@ abstract class Algolia_Index {
 
 		if ( true === $index_exists ) {
 
+			$clear_if_existing = (bool) apply_filters( 'algolia_clear_index_if_existing', $clear_if_existing );
 			if ( true === $clear_if_existing ) {
 				$index->clearIndex();
 			}


### PR DESCRIPTION
A part of bringing multisite support to algolia wordpress: Allows a developer to turn of automatic index truncating. This is required to prevent a site from erasing other sites data.

Previously discussed here: https://github.com/algolia/algoliasearch-wordpress/pull/745