### PR TITLE
feat: add algolia_get_post_object_id filter

### DIFF
--- a/includes/indices/class-algolia-posts-index.php
+++ b/includes/indices/class-algolia-posts-index.php
@@ -243,7 +243,7 @@ final class Algolia_Posts_Index extends Algolia_Index {
 	 * @return string
 	 */
 	private function get_post_object_id( $post_id, $record_index ) {
-		return $post_id . '-' . $record_index;
+		return (string) apply_filters( 'algolia_get_post_object_id', $post_id . '-' . $record_index, $post_id, $record_index );
 	}
 
 	/**

--- a/includes/indices/class-algolia-searchable-posts-index.php
+++ b/includes/indices/class-algolia-searchable-posts-index.php
@@ -227,7 +227,7 @@ final class Algolia_Searchable_Posts_Index extends Algolia_Index {
 	 * @return string
 	 */
 	private function get_post_object_id( $post_id, $record_index ) {
-		return $post_id . '-' . $record_index;
+		return (string) apply_filters( 'algolia_get_post_object_id', $post_id . '-' . $record_index, $post_id, $record_index );
 	}
 
 	/**


### PR DESCRIPTION
A part of bringing multisite support to algolia wordpress: Allows a developer to make object-id’s unique between sites to prevent them collide (risk of overwrite).

Previously discussed here: https://github.com/algolia/algoliasearch-wordpress/pull/750