### PR TITLE
fix: prevents system adding the object back after force delete #775

### DIFF
--- a/includes/watchers/class-algolia-post-changes-watcher.php
+++ b/includes/watchers/class-algolia-post-changes-watcher.php
@@ -10,6 +10,11 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	private $index;
 
 	/**
+	 * @var Array
+	 */
+	private $postsDeleted = array();
+
+	/**
 	 * @param Algolia_Index $index
 	 */
 	public function __construct( Algolia_Index $index ) {
@@ -39,7 +44,12 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @param int $post_id
 	 */
 	public function sync_item( $post_id ) {
+
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if(in_array($post_id, $this->postsDeleted)) {
 			return;
 		}
 
@@ -59,6 +69,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 	 * @param int $post_id
 	 */
 	public function delete_item( $post_id ) {
+
 		$post = get_post( (int) $post_id );
 		if ( ! $post || ! $this->index->supports( $post ) ) {
 			return;
@@ -66,6 +77,7 @@ class Algolia_Post_Changes_Watcher implements Algolia_Changes_Watcher {
 
 		try {
 			$this->index->delete_item( $post );
+			$this->postsDeleted[] = $post->ID; 
 		} catch ( AlgoliaException $exception ) {
 			error_log( $exception->getMessage() );
 		}


### PR DESCRIPTION
This adresses an issue when deleting a post with the force-delete option with an attached featured image. Due to the process of deleting a post, algolia will add back the post when meta data is updated and in this process re-create the post.

This fix is keeping track of what has been deleted from the index and aborts all following actions taken to the post id. This will also affect number of re-index calls consumed while deleting a post in a positive way.