### PR TITLE
Add filter to post thumbnail ID

### DIFF
--- a/includes/class-algolia-utils.php
+++ b/includes/class-algolia-utils.php
@@ -94,6 +94,18 @@ class Algolia_Utils {
 			$post_thumbnail_id = get_post_thumbnail_id( (int) $post_id );
 		}
 
+		/**
+		 * Filter the post thumbnail ID.
+		 * 
+		 * @since 2.11.4
+		 * 
+		 * @param int $post_thumbnail_id 	The post thumbnail ID.
+		 * @param int $post_id 				The post ID.
+		 * 
+		 * @return int
+		 */
+		$post_thumbnail_id = (int) apply_filters( 'algolia_post_thumbnail_id', $post_thumbnail_id, (int) $post_id );
+
 		if ( $post_thumbnail_id ) {
 			$sizes = (array) apply_filters( 'algolia_post_images_sizes', array( 'thumbnail' ) );
 			foreach ( $sizes as $size ) {


### PR DESCRIPTION
I created an [issue](https://github.com/algolia/algoliasearch-wordpress/issues/796) for this a while back before knowing how to create a PR. But now with my new super powers, I was able to make this addition. :)

My use case was that I had a list of people in the search results and I needed a way to have a fallback image for when the person did not have a featured image. The results display the featured image and not having an image threw off my styling.  

Here is the callback I am using with this filter.

```add_filter( 'algolia_post_thumbnail_id', 'prefix_get_post_thumbnail_id', 10, 2 );
/**
 * When a featured image is not present, use another attachment ID provided by database option.
 *
 * @param int $post_thumbnail_id Post thumbnail ID.
 * @param int $post_id Post ID.
 *
 * @return int
 */
function prefix_get_post_thumbnail_id( $post_thumbnail_id, $post_id ) {

	if ( ! in_array( get_post_type( $post_id ), array( 'your_post_type' ), true ) ) {
		return $post_thumbnail_id;
	}

	if ( ! has_post_thumbnail( $post_id ) ) {
		$post_thumbnail_id = intval( 'your_fallback_image_id' );
	} else {
		$post_thumbnail_id = get_post_thumbnail_id( $post_id );
	}
		
	return $post_thumbnail_id;

}```